### PR TITLE
Do not recalculate past data; use cache instead

### DIFF
--- a/projects/client-side-events/datasets/Installer_Events/views/DisplayCountByInstallerType.bq
+++ b/projects/client-side-events/datasets/Installer_Events/views/DisplayCountByInstallerType.bq
@@ -1,42 +1,55 @@
-select * from (SELECT
-  total.date AS date,
-  total.display_count AS total_display_count,
-  v3.display_count AS v3_display_count,
-  (total.display_count - v3.display_count - cap.display_count) AS v2.display_count,
-  cap.display_count AS cap_display_count
+SELECT
+  *
 FROM (
   SELECT
-    DATE(ts) AS date,
-    COUNT(DISTINCT display_id) AS display_count
+    *
   FROM (
     SELECT
-      REGEXP_EXTRACT(protoPayload.resource,r'\/v2\/viewer\/display\/([A-Za-z0-9-]+)') AS display_id,
-      metadata.timestamp AS ts,
-    FROM
-      TABLE_DATE_RANGE(rvaserver2:appengine_logs.appengine_googleapis_com_request_log_, DATE_ADD(CURRENT_TIMESTAMP(), -300, "DAY"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
-    HAVING
-      display_id IS NOT NULL)
-  GROUP BY
-    date)total
-INNER JOIN (
+      total.date AS date,
+      INTEGER(total.display_count) AS total_display_count,
+      INTEGER(v3.display_count) AS v3_display_count,
+      INTEGER((total.display_count - v3.display_count - cap.display_count)) AS v2_display_count,
+      INTEGER(cap.display_count) AS cap_display_count
+    FROM (
+      SELECT
+        DATE(ts) AS date,
+        COUNT(DISTINCT display_id) AS display_count
+      FROM (
+        SELECT
+          REGEXP_EXTRACT(protoPayload.resource,r'\/v2\/viewer\/display\/([A-Za-z0-9-]+)') AS display_id,
+          metadata.timestamp AS ts,
+        FROM
+          TABLE_DATE_RANGE(rvaserver2:appengine_logs.appengine_googleapis_com_request_log_, DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
+        HAVING
+          display_id IS NOT NULL)
+      GROUP BY
+        date)total
+    INNER JOIN (
+      SELECT
+        DATE(ts) AS date,
+        COUNT(DISTINCT display_id) AS display_count
+      FROM
+        TABLE_DATE_RANGE([client-side-events:Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
+      GROUP BY
+        date)v3
+    ON
+      total.date=v3.date
+    INNER JOIN (
+      SELECT
+        DATE(ts) AS date,
+        COUNT(DISTINCT display_id) AS display_count
+      FROM
+        TABLE_DATE_RANGE([client-side-events:CAP_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
+      GROUP BY
+        date)cap
+    ON
+      total.date = cap.date)),
+  (
   SELECT
-    DATE(ts) AS date,
-    COUNT(DISTINCT display_id) AS display_count
+    *
   FROM
-    TABLE_DATE_RANGE([client-side-events:Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -300, "DAY"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
-  GROUP BY
-    date)v3
-ON
-  total.date=v3.date
-INNER JOIN (
-  SELECT
-    DATE(ts) AS date,
-    COUNT(DISTINCT display_id) AS display_count
-  FROM
-    TABLE_DATE_RANGE([client-side-events:CAP_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -300, "DAY"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
-  GROUP BY
-    date)cap
-ON
-  total.date = cap.date) where date >= date("2016-04-01")
+    [client-side-events:Aggregate_Tables.DisplayCountByInstallerType]
+  WHERE
+    date < DATE(DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY")))
 ORDER BY
   date ASC

--- a/projects/client-side-events/datasets/Installer_Events/views/NewInstallationStats.bq
+++ b/projects/client-side-events/datasets/Installer_Events/views/NewInstallationStats.bq
@@ -1,49 +1,61 @@
 SELECT
-  a.date AS date,
-  a.starts AS starts,
-  b.completions AS completions
+  *
 FROM (
   SELECT
-    *
+    a.date AS date,
+    INTEGER(a.starts) AS starts,
+    INTEGER(b.completions) AS completions
   FROM (
     SELECT
-      DATE(ts) AS date,
-      COUNT (DISTINCT display_id) AS starts
-    FROM
-      TABLE_DATE_RANGE([client-side-events:Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -1, "YEAR"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
-    WHERE
-      display_id LIKE '0.%'
-      AND event = 'beginning install'
-    GROUP BY
-      date))a
-LEFT JOIN (
-  SELECT
-    DATE(ts) AS date,
-    COUNT (DISTINCT display_id) AS completions
-  FROM (
-    SELECT
-      *,
-      CONCAT(display_id, DATE(ts)) AS display_date
+      *
     FROM (
       SELECT
-        *
+        DATE(ts) AS date,
+        COUNT (DISTINCT display_id) AS starts
       FROM
-        TABLE_DATE_RANGE([client-side-events:Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -1, "YEAR"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY")))
-    HAVING
-      display_date IN (
-      SELECT
-        CONCAT(display_id, DATE(ts)) AS display_date
-      FROM
-        TABLE_DATE_RANGE([client-side-events:Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -1, "YEAR"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
+        TABLE_DATE_RANGE([client-side-events:Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
       WHERE
         display_id LIKE '0.%'
-        AND event = 'beginning install' ))
+        AND event = 'beginning install'
+      GROUP BY
+        date))a
+  LEFT JOIN (
+    SELECT
+      DATE(ts) AS date,
+      COUNT (DISTINCT display_id) AS completions
+    FROM (
+      SELECT
+        *,
+        CONCAT(display_id, DATE(ts)) AS display_date
+      FROM (
+        SELECT
+          *
+        FROM
+          TABLE_DATE_RANGE([client-side-events:Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY")))
+      HAVING
+        display_date IN (
+        SELECT
+          CONCAT(display_id, DATE(ts)) AS display_date
+        FROM
+          TABLE_DATE_RANGE([client-side-events:Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
+        WHERE
+          display_id LIKE '0.%'
+          AND event = 'beginning install' ))
+    WHERE
+      display_id LIKE '0.%'
+      AND event = 'install complete'
+    GROUP BY
+      date)b
+  ON
+    a.date = b.date
+  ORDER BY
+    date ASC),
+  (
+  SELECT
+    *
+  FROM
+    [client-side-events:Aggregate_Tables.NewInstallationStats]
   WHERE
-    display_id LIKE '0.%'
-    AND event = 'install complete'
-  GROUP BY
-    date)b
-ON
-  a.date = b.date
+    date < DATE(DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY")))
 ORDER BY
   date ASC

--- a/projects/client-side-events/datasets/Installer_Events/views/UpgradeStats.bq
+++ b/projects/client-side-events/datasets/Installer_Events/views/UpgradeStats.bq
@@ -1,47 +1,59 @@
 SELECT
-  a.date AS date,
-  a.starts AS starts,
-  b.completions AS completions
+  *
 FROM (
   SELECT
-    DATE(ts) AS date,
-    COUNT (DISTINCT display_id) AS starts
-  FROM
-    TABLE_DATE_RANGE([client-side-events:Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -1, "YEAR"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
-  WHERE
-    display_id NOT LIKE '0.%'
-    AND (( event = 'downloading components'
-        AND event_details != '')
-      OR (event = 'upgrading installer')
-      OR (event = 'downloading latest version'))
-  GROUP BY
-    date)a
-LEFT JOIN (
-  SELECT
-    DATE(ts) AS date,
-    COUNT (DISTINCT display_id) AS completions
+    a.date AS date,
+    INTEGER(a.starts) AS starts,
+    INTEGER(b.completions) AS completions
   FROM (
     SELECT
-      *,
-      CONCAT(display_id, DATE(ts)) AS display_date
+      DATE(ts) AS date,
+      COUNT (DISTINCT display_id) AS starts
     FROM
-      TABLE_DATE_RANGE([client-side-events:Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -1, "YEAR"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY")))
-  WHERE
-    display_id NOT LIKE '0.%'
-    AND event = 'install complete'
-    AND display_date IN (
-    SELECT
-      CONCAT(display_id, DATE(ts)) AS display_date
-    FROM
-      TABLE_DATE_RANGE([client-side-events:Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -1, "YEAR"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
+      TABLE_DATE_RANGE([client-side-events:Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
     WHERE
-      (event = 'downloading components'
-        AND event_details != '')
-      OR event = 'upgrading installer'
-      OR event = 'downloading latest version')
-  GROUP BY
-    date)b
-ON
-  a.date = b.date
+      display_id NOT LIKE '0.%'
+      AND (( event = 'downloading components'
+          AND event_details != '')
+        OR (event = 'upgrading installer')
+        OR (event = 'downloading latest version'))
+    GROUP BY
+      date)a
+  LEFT JOIN (
+    SELECT
+      DATE(ts) AS date,
+      COUNT (DISTINCT display_id) AS completions
+    FROM (
+      SELECT
+        *,
+        CONCAT(display_id, DATE(ts)) AS display_date
+      FROM
+        TABLE_DATE_RANGE([client-side-events:Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY")))
+    WHERE
+      display_id NOT LIKE '0.%'
+      AND event = 'install complete'
+      AND display_date IN (
+      SELECT
+        CONCAT(display_id, DATE(ts)) AS display_date
+      FROM
+        TABLE_DATE_RANGE([client-side-events:Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
+      WHERE
+        (event = 'downloading components'
+          AND event_details != '')
+        OR event = 'upgrading installer'
+        OR event = 'downloading latest version')
+    GROUP BY
+      date)b
+  ON
+    a.date = b.date
+  ORDER BY
+    date ASC),
+  (
+  SELECT
+    *
+  FROM
+    [client-side-events:Aggregate_Tables.UpgradeStats]
+  WHERE
+    date < DATE(DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY")))
 ORDER BY
   date ASC

--- a/projects/client-side-events/datasets/Native_Events/views/MultipleUnreliableV3StartsPlayerCount.bq
+++ b/projects/client-side-events/datasets/Native_Events/views/MultipleUnreliableV3StartsPlayerCount.bq
@@ -1,46 +1,54 @@
 SELECT
-  ddate,
-  COUNT(DISTINCT displayid) AS ungracefulMultiStartRecentDisplayCount
+  *
 FROM (
   SELECT
-    recentUngracefulPlayerStartup.pdate AS ddate,
-    recentUngracefulPlayerStartup.display_id AS displayid,
-    recentUngracefulPlayerStartup.startupCount,
-    recentV3.idate
+    ddate,
+    INTEGER(COUNT(DISTINCT displayid)) AS ungracefulMultiStartRecentDisplayCount
   FROM (
     SELECT
-      DATE(ts) AS pdate,
-      display_id,
-      COUNT(display_id) AS startupCount
-    FROM
-      TABLE_DATE_RANGE([Native_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -6, "MONTH"), CURRENT_TIMESTAMP())
-    WHERE
-      (event = 'startup'
-        AND event_details NOT LIKE "%graceful%"
-        OR event LIKE '%heartbeat%')
-      AND player_version > '2016.02.24.13.00'
-      AND display_id IS NOT NULL
-    GROUP BY
-      pdate,
-      display_id) recentUngracefulPlayerStartup
-  LEFT JOIN (
-    SELECT
-      DATE(ts) AS idate,
-      display_id
-    FROM
-      TABLE_DATE_RANGE([Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -6, "MONTH"),CURRENT_TIMESTAMP())
-    WHERE
-      installer_version > "2015"
-    GROUP BY
-      idate,
-      display_id ) recentV3
-  ON
-    recentV3.idate = recentUngracefulPlayerStartup.pdate
-    AND recentV3.display_id = recentUngracefulPlayerStartup.display_id
-  HAVING
-    recentV3.idate IS NOT NULL
-    AND recentUngracefulPlayerStartup.startupCount > 2)
-GROUP BY
-  ddate
+      recentUngracefulPlayerStartup.pdate AS ddate,
+      recentUngracefulPlayerStartup.display_id AS displayid,
+      recentUngracefulPlayerStartup.startupCount,
+      recentV3.idate
+    FROM (
+      SELECT
+        DATE(ts) AS pdate,
+        display_id,
+        COUNT(display_id) AS startupCount
+      FROM
+        TABLE_DATE_RANGE([Native_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
+      WHERE
+        (event = 'startup'
+          AND event_details NOT LIKE "%graceful%"
+          OR event LIKE '%heartbeat%')
+        AND player_version > '2016.02.24.13.00'
+        AND display_id IS NOT NULL
+      GROUP BY
+        pdate,
+        display_id) recentUngracefulPlayerStartup
+    LEFT JOIN (
+      SELECT
+        DATE(ts) AS idate,
+        display_id
+      FROM
+        TABLE_DATE_RANGE([Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
+      WHERE
+        installer_version > "2015"
+      GROUP BY
+        idate,
+        display_id ) recentV3
+    ON
+      recentV3.idate = recentUngracefulPlayerStartup.pdate
+      AND recentV3.display_id = recentUngracefulPlayerStartup.display_id
+    HAVING
+      recentV3.idate IS NOT NULL
+      AND recentUngracefulPlayerStartup.startupCount > 2)
+  GROUP BY
+    ddate ),
+  (
+  SELECT
+    * from[client-side-events:Aggregate_Tables.MultipleUnreliableV3StartsPlayerCount]
+  WHERE
+    ddate < DATE(DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY")))
 ORDER BY
   ddate

--- a/projects/client-side-events/datasets/Native_Events/views/PlayerReliabilityStats.bq
+++ b/projects/client-side-events/datasets/Native_Events/views/PlayerReliabilityStats.bq
@@ -3,19 +3,19 @@ SELECT
 FROM (
   SELECT
     total.date AS date,
-    total.number AS total_number,
-    startups.number AS startups_number,
-    scheduled_reboots.number AS scheduled_reboots_number,
-    modern.number AS modern_number,
-    startups_from_reboot.number AS startups_from_reboot_number,
-    graceful.number AS startups_after_graceful_shutdown,
-    v3MultipleStart.ungracefulMultiStartRecentDisplayCount AS v3_displays_with_multiple_ungraceful_startups
+    INTEGER(total.number) AS total_number,
+    INTEGER(startups.number) AS startups_number,
+    INTEGER(scheduled_reboots.number) AS scheduled_reboots_number,
+    INTEGER(modern.number) AS modern_number,
+    INTEGER(startups_from_reboot.number) AS startups_from_reboot_number,
+    INTEGER(graceful.number) AS startups_after_graceful_shutdown,
+    INTEGER(v3MultipleStart.ungracefulMultiStartRecentDisplayCount) AS v3_displays_with_multiple_ungraceful_startups
   FROM (
     SELECT
       COUNT(DISTINCT display_id) AS number,
       DATE(ts) AS date
     FROM
-      TABLE_DATE_RANGE([Native_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -6, 'MONTH'), CURRENT_TIMESTAMP())
+      TABLE_DATE_RANGE([Native_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, 'DAY'), DATE_ADD(CURRENT_TIMESTAMP(), -1, 'DAY'))
     GROUP BY
       date)total
   JOIN (
@@ -23,7 +23,7 @@ FROM (
       COUNT(DISTINCT display_id) AS number,
       DATE(ts) AS date
     FROM
-      TABLE_DATE_RANGE([Native_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -6, 'MONTH'), CURRENT_TIMESTAMP())
+      TABLE_DATE_RANGE([Native_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, 'DAY'), DATE_ADD(CURRENT_TIMESTAMP(), -1, 'DAY'))
     WHERE
       event = 'startup'
     GROUP BY
@@ -35,7 +35,7 @@ FROM (
       COUNT(DISTINCT display_id) AS number,
       DATE(ts) AS date
     FROM
-      TABLE_DATE_RANGE([Native_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -6, 'MONTH'), CURRENT_TIMESTAMP())
+      TABLE_DATE_RANGE([Native_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, 'DAY'), DATE_ADD(CURRENT_TIMESTAMP(), -1, 'DAY'))
     WHERE
       event = 'timer restart'
     GROUP BY
@@ -47,7 +47,7 @@ FROM (
       COUNT(DISTINCT display_id) AS number,
       DATE(ts) AS date
     FROM
-      TABLE_DATE_RANGE([Native_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -6, 'MONTH'), CURRENT_TIMESTAMP())
+      TABLE_DATE_RANGE([Native_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, 'DAY'), DATE_ADD(CURRENT_TIMESTAMP(), -1, 'DAY'))
     WHERE
       player_version > '2016.02.24.13.00'
       AND event = 'startup'
@@ -60,7 +60,7 @@ FROM (
       COUNT(DISTINCT display_id) AS number,
       DATE(ts) AS date
     FROM
-      TABLE_DATE_RANGE([Native_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -6, 'MONTH'), CURRENT_TIMESTAMP())
+      TABLE_DATE_RANGE([Native_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, 'DAY'), DATE_ADD(CURRENT_TIMESTAMP(), -1, 'DAY'))
     WHERE
       player_version >= '2016.02.05.10.00'
       AND event = 'startup'
@@ -74,7 +74,7 @@ FROM (
       COUNT(DISTINCT display_id) AS number,
       DATE(ts) AS date
     FROM
-      TABLE_DATE_RANGE([Native_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -6, 'MONTH'), CURRENT_TIMESTAMP())
+      TABLE_DATE_RANGE([Native_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, 'DAY'), DATE_ADD(CURRENT_TIMESTAMP(), -1, 'DAY'))
     WHERE
       event = 'startup'
       AND event_details LIKE '%after graceful shutdown%'
@@ -82,15 +82,20 @@ FROM (
       date)graceful
   ON
     total.date = graceful.date
-  LEFT OUTER JOIN (
+  JOIN (
     SELECT
       ungracefulMultiStartRecentDisplayCount,
       ddate
     FROM
-      Native_Events.MultipleUnreliableV3StartsPlayerCount) v3MultipleStart
+      Aggregate_Tables.MultipleUnreliableV3StartsPlayerCount) v3MultipleStart
   ON
-    v3MultipleStart.ddate = graceful.date)
-WHERE
-  date >= DATE("2016-04-01")
+    v3MultipleStart.ddate = total.date),
+  (
+  SELECT
+    *
+  FROM
+    [client-side-events:Aggregate_Tables.PlayerReliabilityStats]
+  WHERE
+    date < DATE(DATE_ADD(CURRENT_TIMESTAMP(), -3, 'DAY')))
 ORDER BY
   date ASC


### PR DESCRIPTION
@tejohnso @fjvallarino ready for review.

There are some changes that might seem weird and unnecessary. Most of those changes were made to work around BigQuery quirks.

This needs to go in after https://github.com/Rise-Vision/client-side-events/pull/18