### PR TITLE
Don't use core logs for v3 counts

### DIFF
--- a/projects/client-side-events/datasets/Installer_Events/views/DisplayCountByInstallerType.bq
+++ b/projects/client-side-events/datasets/Installer_Events/views/DisplayCountByInstallerType.bq
@@ -6,9 +6,9 @@ FROM (
   FROM (
     SELECT
       total.date AS date,
-      INTEGER(total.display_count) AS total_display_count,
+      INTEGER(total.display_count - v3_api_exclude.display_count + v3.display_count) AS total_display_count,
       INTEGER(v3.display_count) AS v3_display_count,
-      INTEGER((total.display_count - v3.display_count - cap.display_count)) AS v2_display_count,
+      INTEGER((total.display_count - v3_api_exclude.display_count - cap.display_count)) AS v2_display_count,
       INTEGER(cap.display_count) AS cap_display_count
     FROM (
       SELECT
@@ -24,6 +24,14 @@ FROM (
           display_id IS NOT NULL)
       GROUP BY
         date)total
+    LEFT JOIN (
+      SELECT
+        date,
+        display_count
+      FROM
+        [client-side-events:Viewer_Events.APICallsFromV3]) v3_api_exclude
+    ON
+      v3_api_exclude.date = total.date
     LEFT JOIN (
       SELECT
         DATE(ts) AS date,
@@ -52,4 +60,4 @@ FROM (
   WHERE
     date < DATE(DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY")))
 ORDER BY
-  date ASC
+  date asc

--- a/projects/client-side-events/datasets/Viewer_Events/views/APICallsFromV3.bq
+++ b/projects/client-side-events/datasets/Viewer_Events/views/APICallsFromV3.bq
@@ -1,0 +1,15 @@
+SELECT
+  date,
+  COUNT(DISTINCT display_id) AS display_count
+FROM (
+  SELECT
+    REGEXP_EXTRACT(protoPayload.resource,r'\/v2\/viewer\/display\/([A-Za-z0-9-]+)') AS display_id,
+    REGEXP_EXTRACT(protoPayload.resource,r'\/v2\/viewer\/display.*&pn=([A-Za-z0-9-]+)') AS type,
+    DATE(metadata.timestamp) AS date,
+  FROM
+    TABLE_DATE_RANGE(rvaserver2:appengine_logs.appengine_googleapis_com_request_log_, DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
+  HAVING
+    display_id IS NOT NULL
+    AND type = "RisePlayerElectron" )
+GROUP BY
+  date


### PR DESCRIPTION
Since v3 players with recent viewer versions no longer use the core api
call, we can't rely on accurate core counts for v3.

This removes the v3 player counts from the total count coming from core
logs and adds the Installer_Events count to get v3 total.

@fjvallarino please review