### PR TITLE
Chore/add system metrics queries

### DIFF
--- a/projects/client-side-events/datasets/System_Metrics_Events/views/WeekAverages.bq
+++ b/projects/client-side-events/datasets/System_Metrics_Events/views/WeekAverages.bq
@@ -1,0 +1,15 @@
+SELECT * FROM
+(
+  SELECT
+    EXACT_COUNT_DISTINCT(display_id) as count,
+    YEAR(ts) AS year,
+    WEEK(TS) AS week,
+    ROUND(AVG(cpu_usage)*100) as avgCPUUsage,
+    ROUND(AVG(memory_usage)*100) as avgMemUsage,
+    ROUND(AVG(free_disk)/1024) as freeDiskGB
+  FROM System_Metrics_Events.events
+  WHERE cpu_usage IS NOT NULL AND memory_usage IS NOT NULL AND free_disk IS NOT NULL
+  GROUP BY year, week
+  ORDER BY year DESC, week DESC
+  LIMIT 1000
+)

--- a/projects/client-side-events/datasets/System_Metrics_Events/views/WeekAveragesByPlatform.bq
+++ b/projects/client-side-events/datasets/System_Metrics_Events/views/WeekAveragesByPlatform.bq
@@ -1,0 +1,43 @@
+SELECT * FROM
+(
+  SELECT
+    EXACT_COUNT_DISTINCT(e.display_id) as count,
+    YEAR(e.ts) AS year,
+    WEEK(e.ts) AS week,
+    p.platform AS platform,
+    ROUND(AVG(e.cpu_usage)*100) as avgCPUUsage,
+    ROUND(AVG(e.memory_usage)*100) as avgMemUsage,
+    ROUND(AVG(e.free_disk)/1024) as freeDiskGB
+  FROM [System_Metrics_Events.events] AS e
+  INNER JOIN
+  (
+    SELECT display_id,
+      CASE
+        WHEN UPPER(a.os_description) CONTAINS "WIN" THEN 'Windows'
+        WHEN UPPER(a.os_description) CONTAINS "UBUNTU" THEN 'Linux'
+        WHEN UPPER(a.os_description) CONTAINS "ARM" THEN 'Raspbian'
+        WHEN UPPER(a.os_description) CONTAINS "LINUX" THEN 'Linux'
+        WHEN UPPER(a.os_description) CONTAINS "LNX" THEN 'Linux'
+        WHEN UPPER(a.os_description) CONTAINS "ANDROID" THEN 'Android'
+        WHEN UPPER(a.os_description) CONTAINS "RSP" THEN 'Raspbian'
+        WHEN UPPER(a.os_description) CONTAINS "CROS" THEN 'ChromeOS'
+        WHEN UPPER(a.os_description) CONTAINS "MAC" THEN 'Mac'
+        WHEN UPPER(a.os_description) CONTAINS "FEDORA" THEN 'Linux'
+        WHEN UPPER(a.os_description) CONTAINS "PEPPERMINT" THEN 'Linux'
+        WHEN UPPER(a.os_description) CONTAINS "UNDEFINED" THEN 'Unknown'
+        WHEN UPPER(a.os_description) = "" THEN 'Unknown'
+        ELSE a.os_description
+      END AS platform,
+    FROM
+    (
+      SELECT display_id, os_description, MAX(ts)
+      FROM [Player_Data.configuration]
+      GROUP BY display_id, os_description
+    ) AS a
+  ) AS p
+  ON e.display_id = p.display_id
+  WHERE e.cpu_usage IS NOT NULL AND e.memory_usage IS NOT NULL AND e.free_disk IS NOT NULL
+  GROUP BY year, week, platform
+  ORDER BY year DESC, week DESC, count DESC
+  LIMIT 1000
+)

--- a/projects/client-side-events/datasets/System_Metrics_Events/views/WeekAveragesUptime
+++ b/projects/client-side-events/datasets/System_Metrics_Events/views/WeekAveragesUptime
@@ -1,0 +1,34 @@
+SELECT * FROM
+(
+  SELECT
+    EXACT_COUNT_DISTINCT(display_id) as count,
+    YEAR(ts) AS year,
+    WEEK(TS) AS week,
+    CASE
+      WHEN display_id IN ('784U6HHHYMMQ', 'FB6SAP8CVZNK') THEN 'Raspbian'
+      WHEN display_id IN ('PMPRUBNMRCXE', 'PKZJRKHH8QM3', 'JAQVBQS84SGK', 'V4EFG77W59ME') THEN 'Ubuntu'
+      ELSE 'Windows'
+    END AS platform,
+    ROUND(AVG(cpu_usage)*100) as avgCPUUsage,
+    ROUND(AVG(memory_usage)*100) as avgMemUsage,
+    ROUND(AVG(free_disk)/1024) as freeDiskGB
+  FROM System_Metrics_Events.events
+  WHERE cpu_usage IS NOT NULL AND memory_usage IS NOT NULL AND free_disk IS NOT NULL
+  AND display_id IN
+  (
+    '784U6HHHYMMQ',#Raspbian
+    'FB6SAP8CVZNK',#Raspbian
+    'PMPRUBNMRCXE',#ubuntu 14.04 x 32#ubuntu 14.04 x 32
+    'PKZJRKHH8QM3',#ubuntu 14.04 x 32#ubuntu 14.04 x 64
+    'JAQVBQS84SGK',#ubuntu 14.04 x 32#ubuntu 16.04 x 64
+    'V4EFG77W59ME',#ubuntu 14.04 x 32#ubuntu 16.04 x 64
+    '89YMNGW3J8SE',#windows 10 x 32
+    'MMZ4NHZA3RCG',#windows 10 x 64
+    'REGGBURN2E7J',#windows 7 x 32
+    'NFEUBNQ4A7D6',#windows embedded x 32
+    'DZ7UA3776XJB' #windows 10 x 32
+  )
+  GROUP BY year, week, platform
+  ORDER BY year DESC, week DESC, count DESC
+  LIMIT 1000
+)


### PR DESCRIPTION
So we can report player usage in a weekly basis globally or per platform.