### PR TITLE
Installer and upgrade reliability based on latest installer version

### DIFF
--- a/projects/client-side-events/datasets/Installer_Events/views/ModuleUpgradeStats.bq
+++ b/projects/client-side-events/datasets/Installer_Events/views/ModuleUpgradeStats.bq
@@ -13,7 +13,7 @@ FROM (
       TABLE_DATE_RANGE([client-side-events:Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY"))
     WHERE
       display_id NOT LIKE "0.%"
-      AND installer_version NOT LIKE "beta_%"
+      AND installer_version = "XXXX.XX.XX.XX.XX"
       AND event = "checking for upgrade"
     GROUP BY
       date)a
@@ -29,7 +29,7 @@ FROM (
         TABLE_DATE_RANGE([client-side-events:Installer_Events.events], DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY"), DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY")))
     WHERE
       display_id NOT LIKE "0.%"
-      AND installer_version NOT LIKE "beta_%"
+      AND installer_version = "XXXX.XX.XX.XX.XX"
       AND event = "install complete"
       AND display_date NOT IN (
       SELECT

--- a/projects/client-side-events/datasets/Installer_Events/views/NewInstallationStats.bq
+++ b/projects/client-side-events/datasets/Installer_Events/views/NewInstallationStats.bq
@@ -17,7 +17,7 @@ FROM (
       WHERE
         display_id LIKE '0.%'
         AND event = 'beginning install'
-        AND installer_version NOT LIKE "beta_%"
+        AND installer_version = "XXXX.XX.XX.XX.XX"
       GROUP BY
         date))a
   LEFT JOIN (
@@ -42,11 +42,11 @@ FROM (
         WHERE
           display_id LIKE '0.%'
           AND event = 'beginning install'
-          AND installer_version NOT LIKE "beta_%" ))
+          AND installer_version = "XXXX.XX.XX.XX.XX" ))
     WHERE
       display_id LIKE '0.%'
       AND event = 'install complete'
-      AND installer_version NOT LIKE "beta_%"
+      AND installer_version = "XXXX.XX.XX.XX.XX"
     GROUP BY
       date)b
   ON


### PR DESCRIPTION
- To give us accurate stable Launcher (installer) reliability stats, the query should be based on latest stable version. I will have to update the query every time we release a new installer to stable
- Can't use MAX as we will continuously build staged installers with a version higher than stable