### PR TITLE
Fix/change references from 'play' to 'configuration' on image reliability

### DIFF
--- a/projects/client-side-events/datasets/Rise_Cache_V2/views/CacheV2DailyReliability.bq
+++ b/projects/client-side-events/datasets/Rise_Cache_V2/views/CacheV2DailyReliability.bq
@@ -33,5 +33,5 @@ FROM
       GROUP BY date) error ON total.date = error.date
    ORDER BY total.date),
   (SELECT *
-   FROM[client-side-EVENTS:Aggregate_Tables.CacheV2DailyReliability]
+   FROM[client-side-events:Aggregate_Tables.CacheV2DailyReliability]
    WHERE total_date < DATE(DATE_ADD(CURRENT_TIMESTAMP(), -1, "DAY")))

--- a/projects/client-side-events/datasets/Widget_Events/views/ImageDailyReliability.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/ImageDailyReliability.bq
@@ -8,7 +8,7 @@ FROM
      (SELECT COUNT(DISTINCT display_id) AS usageCount,
              Date(ts) AS date
       FROM TABLE_DATE_RANGE(Widget_Events.image_events, DATE_ADD(CURRENT_TIMESTAMP(), -10, 'DAY'), CURRENT_TIMESTAMP())
-      WHERE event = 'play'
+      WHERE event = 'configuration'
         AND display_id NOT IN ('preview',
                                '"display_id"',
                                '"displayId"')
@@ -29,5 +29,5 @@ FROM
       GROUP BY date) AS error ON usage.date=error.date
    ORDER BY usage.date),
   (SELECT *
-   FROM[client-side-EVENTS:Aggregate_Tables.ImageDailyReliability]
+   FROM[client-side-events:Aggregate_Tables.ImageDailyReliability]
    WHERE usage_date < DATE(DATE_ADD(CURRENT_TIMESTAMP(), -10, "DAY")))

--- a/projects/client-side-events/datasets/Widget_Events/views/RssDailyReliability.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/RssDailyReliability.bq
@@ -34,5 +34,5 @@ FROM
       GROUP BY date) AS componentUsage ON usage.date=componentUsage.date
    ORDER BY usage.date),
   (SELECT *
-   FROM[client-side-EVENTS:Aggregate_Tables.RssDailyReliability]
+   FROM[client-side-events:Aggregate_Tables.RssDailyReliability]
    WHERE usage_date < DATE(DATE_ADD(CURRENT_TIMESTAMP(), -10, "DAY")))

--- a/projects/client-side-events/datasets/Widget_Events/views/SpreadsheetDailyReliability.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/SpreadsheetDailyReliability.bq
@@ -37,5 +37,5 @@ FROM
       GROUP BY date) componentUsage ON usage.date=componentUsage.date
    ORDER BY usage.date),
   (SELECT *
-   FROM[client-side-EVENTS:Aggregate_Tables.SpreadsheetDailyReliability]
+   FROM[client-side-events:Aggregate_Tables.SpreadsheetDailyReliability]
    WHERE usage_date < DATE(DATE_ADD(CURRENT_TIMESTAMP(), -10, "DAY")))

--- a/projects/client-side-events/datasets/Widget_Events/views/TextDailyReliability.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/TextDailyReliability.bq
@@ -26,5 +26,5 @@ FROM
       GROUP BY date) AS error ON usage.date=error.date
    ORDER BY usage.date),
   (SELECT *
-   FROM[client-side-EVENTS:Aggregate_Tables.TextDailyReliability]
+   FROM[client-side-events:Aggregate_Tables.TextDailyReliability]
    WHERE usage_date < DATE(DATE_ADD(CURRENT_TIMESTAMP(), -10, "DAY")))


### PR DESCRIPTION
- for image widget queries changed references from `play` event to `configuration` event as per `widget-image` [#141](https://github.com/Rise-Vision/widget-image/pull/141)
- fixed typo `client-side-EVENTS` --> `client-side-events`