### PR TITLE
Adding Image and Video use RLS views

### DIFF
--- a/projects/client-side-events/datasets/Widget_Events/views/ImageRLSStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/ImageRLSStats.bq
@@ -1,0 +1,51 @@
+#standardSQL
+
+WITH
+
+allDisplays AS (
+  SELECT DATE(ts) AS date, display_id, event, event_details, error_details, file_url
+  FROM `client-side-events.Widget_Events.image_events*`
+  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+  AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND version = "0.1.1"
+)
+
+SELECT * FROM (
+  SELECT
+    a.date AS date,
+    a.total_count AS total_count,
+    IFNULL(b.failed_count, 0) AS failed_count
+  FROM (
+    SELECT date, COUNT(DISTINCT(display_id)) AS total_count
+    FROM allDisplays
+    WHERE (event = "configuration" AND event_details = "storage file")
+    GROUP BY date
+  ) a
+  LEFT JOIN (
+    SELECT date, COUNT(DISTINCT(display_id)) AS failed_count
+    FROM (
+      SELECT date, display_id FROM allDisplays
+      WHERE event = "error"
+      AND (
+        event_details IN ('no connection', 'required modules unavailable', 'unauthorized', 'file does not exist') OR
+        (error_details IS NOT NULL AND file_url NOT LIKE "%localhost:94%" AND file_url NOT LIKE "https://storage-dot-rvaserver2.appspot.com%")
+      )
+      AND CONCAT(display_id, CAST(date AS STRING)) IN
+                (
+                  SELECT CONCAT(display_id, CAST(date AS STRING))
+                  FROM allDisplays
+                  WHERE (event = "configuration" AND event_details = "storage file")
+                )
+    )
+    GROUP BY date
+  ) b
+  ON a.date = b.date
+
+  UNION ALL
+
+  SELECT date, total_count, failed_count
+  FROM `client-side-events.Aggregate_Tables.ImageRLSStats`
+  WHERE date < DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY)
+)
+ORDER BY date DESC

--- a/projects/client-side-events/datasets/Widget_Events/views/VideoRLSStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/VideoRLSStats.bq
@@ -1,0 +1,63 @@
+#standardSQL
+
+WITH
+
+allDisplays AS (
+  SELECT DATE(ts) AS date, display_id, event, event_details, file_url, local_url
+  FROM `client-side-events.Widget_Events.video_v2_events*`
+  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+  AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND version = "1.1.0"
+)
+
+SELECT * FROM (
+  SELECT
+    a.date AS date,
+    a.total_count AS total_count,
+    IFNULL(b.failed_count, 0) AS failed_count
+  FROM (
+    SELECT date, COUNT(DISTINCT(display_id)) AS total_count
+    FROM allDisplays
+    WHERE (event = "configuration" AND event_details = "storage file")
+    GROUP BY date
+  ) a
+  LEFT JOIN (
+    SELECT date, COUNT(DISTINCT(display_id)) AS failed_count
+    FROM (
+      SELECT date, display_id FROM allDisplays
+      WHERE event = "error"
+      AND (event_details IN ('no connection', 'required modules unavailable', 'unauthorized', 'file does not exist') OR
+        file_url NOT LIKE "%localhost:94%")
+      AND CONCAT(display_id, CAST(date AS STRING)) IN
+                (
+                  SELECT CONCAT(display_id, CAST(date AS STRING))
+                  FROM allDisplays
+                  WHERE (event = "configuration" AND event_details = "storage file")
+                )
+
+      UNION ALL
+
+      SELECT date, display_id FROM allDisplays
+      WHERE event = "player error"
+      AND (event_details = 'video - Error loading media: File could not be played' OR event_details LIKE '%MEDIA_ERR%')
+      AND file_url NOT LIKE "%localhost:94%"
+      AND local_url IS NOT NULL
+      AND CONCAT(display_id, CAST(date AS STRING)) IN (
+        SELECT CONCAT(display_id, CAST(date AS STRING))
+        FROM allDisplays
+        WHERE (event = "configuration" AND event_details = "storage file")
+      )
+    )
+
+    GROUP BY date
+  ) b
+  ON a.date = b.date
+
+  UNION ALL
+
+  SELECT date, total_count, failed_count
+  FROM `client-side-events.Aggregate_Tables.VideoRLSStats`
+  WHERE date < DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY)
+)
+ORDER BY date DESC


### PR DESCRIPTION
- Written initially to filter for only single storage file (through RLS single file rollout)
- Conditions specify the stats to be from displays that are configured for storage single file and use RLS only