### PR TITLE
Ignore "Credentials do not exist" log on reliability

### DIFF
--- a/projects/client-side-events/datasets/Component_Events/views/TwitterDailyReliability.bq
+++ b/projects/client-side-events/datasets/Component_Events/views/TwitterDailyReliability.bq
@@ -28,7 +28,7 @@ LEFT JOIN
     /* Select displays that have module errors */
     SELECT display_id, DATE(ts) AS date 
     FROM `client-side-events.Module_Events.tweet_events` 
-    WHERE event = "error"
+    WHERE event = "error" and STARTS_WITH(event_details, "Credentials do not exist") IS FALSE
     GROUP BY display_id, date
     
     UNION ALL


### PR DESCRIPTION
This log is called on every module restart and is skewing our reliability.
@Rise-Vision/content please review