### PR TITLE
Filter out beta displays for RLS single file stats

### DIFF
--- a/projects/client-side-events/datasets/Widget_Events/views/ImageRLSStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/ImageRLSStats.bq
@@ -8,6 +8,14 @@ allDisplays AS (
   WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
   AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
   AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND display_id IN (
+    SELECT DISTINCT(display_id)
+      FROM `client-side-events.Installer_Events.events*`
+      WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+      AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+      AND installer_version NOT LIKE "beta_%"
+      AND event = "install complete"
+  )
 )
 
 SELECT * FROM (

--- a/projects/client-side-events/datasets/Widget_Events/views/VideoRLSStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/VideoRLSStats.bq
@@ -8,6 +8,14 @@ allDisplays AS (
   WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
   AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
   AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND display_id IN (
+    SELECT DISTINCT(display_id)
+      FROM `client-side-events.Installer_Events.events*`
+      WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+      AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+      AND installer_version NOT LIKE "beta_%"
+      AND event = "install complete"
+  )
 )
 
 SELECT * FROM (


### PR DESCRIPTION
- Filter out beta displays for Image & Video RLS single file stats. Leveraging the `beta_` prefix that Installer adds to the `installer_version`. 

@jungeunyoon @santiagonoguez This was the most straight forward and accurate way I've seen to filter out beta displays, some reasoning is:

- If I chose to use the latest module version of Launcher or Player, it couples the Widgets reliability to Player releases which would skew the stats. 
- If I chose to use the player configuration table `player_name` field which gets _(Beta)_  prefixed to the name, there is a chance within the 3 day range specified that the display switched from Stable to Beta or vice versa. A likely rare scenario, but it is possible and might skew stats. 

@Rise-Vision/delivery FYI