### PR TITLE
Change watchdog reliability query to catch errors that were not being reported

### DIFF
--- a/projects/client-side-events/datasets/Module_Events/watchdog_reliability.bq
+++ b/projects/client-side-events/datasets/Module_Events/watchdog_reliability.bq
@@ -21,7 +21,7 @@ moduleErrorsCurrentVersion AS (
   FROM
     recentEventsCurrentVersion
   WHERE
-    event = "error" )
+    event like "%error%" )
 
 SELECT
   total.date,


### PR DESCRIPTION
We changed it in BigQuery on Jun-5 but I forgot to change it here.