### PR TITLE
Ensure no displays using RLS are included

### DIFF
--- a/projects/client-side-events/datasets/Widget_Events/views/ImageDailyReliability.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/ImageDailyReliability.bq
@@ -9,6 +9,7 @@ FROM
              Date(ts) AS date
       FROM TABLE_DATE_RANGE(Widget_Events.image_events, DATE_ADD(CURRENT_TIMESTAMP(), -10, 'DAY'), CURRENT_TIMESTAMP())
       WHERE event = 'configuration'
+        AND event_details NOT LIKE "%(rls)%"
         AND display_id NOT IN ('preview',
                                '"display_id"',
                                '"displayId"')

--- a/projects/client-side-events/datasets/Widget_Events/views/VideoDailyReliability.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/VideoDailyReliability.bq
@@ -15,7 +15,8 @@ FROM (
     FROM
       TABLE_DATE_RANGE(Widget_Events.video_v2_events, DATE_ADD(CURRENT_TIMESTAMP(), -10, 'DAY'), CURRENT_TIMESTAMP())
     WHERE
-      event = 'play'
+      event = 'configuration'
+      AND event_details NOT LIKE "%(rls)%"
       AND display_id NOT IN ('preview',
         '"display_id"',
         '"displayId"')


### PR DESCRIPTION
- We are tracking Image/Video using RLS reliability separately, so these original Image/Video reliability queries will eventually become obsolete. For now, exclude displays using RLS so reliability is solely based on using Rise Cache