### PR TITLE
Improving specificity in Image/Video RLS and Video reliability stats

### DIFF
--- a/projects/client-side-events/datasets/Widget_Events/views/ImageRLSStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/ImageRLSStats.bq
@@ -35,7 +35,7 @@ SELECT * FROM (
       SELECT date, display_id FROM allDisplays
       WHERE event = "error"
       AND (
-        event_details IN ('no connection', 'required modules unavailable', 'unauthorized', 'file does not exist') OR
+        event_details IN ('no connection', 'required modules unavailable') OR
         (error_details IS NOT NULL AND file_url NOT LIKE "%localhost:94%" AND file_url NOT LIKE "https://storage-dot-rvaserver2.appspot.com%")
       )
       AND CONCAT(display_id, CAST(date AS STRING)) IN

--- a/projects/client-side-events/datasets/Widget_Events/views/VideoDailyReliability.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/VideoDailyReliability.bq
@@ -70,6 +70,7 @@ OUTER JOIN EACH (
           event IN ('player error')
           AND (event_details = 'video - Error loading media: File could not be played'
           OR event_details CONTAINS 'MEDIA_ERR')
+          AND file_url NOT LIKE "risemedialibrary-%"
           AND (version='2.0.0' OR version='1.1.0')),
         (
         SELECT

--- a/projects/client-side-events/datasets/Widget_Events/views/VideoRLSStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/VideoRLSStats.bq
@@ -34,8 +34,8 @@ SELECT * FROM (
     FROM (
       SELECT date, display_id FROM allDisplays
       WHERE event = "error"
-      AND (event_details IN ('no connection', 'required modules unavailable', 'unauthorized', 'file does not exist') OR
-        file_url NOT LIKE "%localhost:94%")
+      AND (event_details IN ('no connection', 'required modules unavailable') OR
+        (file_url NOT LIKE "%localhost:94%" AND file_url NOT LIKE "https://storage-dot-rvaserver2.appspot.com%"))
       AND CONCAT(display_id, CAST(date AS STRING)) IN
                 (
                   SELECT CONCAT(display_id, CAST(date AS STRING))
@@ -47,7 +47,6 @@ SELECT * FROM (
 
       SELECT date, display_id FROM allDisplays
       WHERE event = "player error"
-      AND (event_details = 'video - Error loading media: File could not be played' OR event_details LIKE '%MEDIA_ERR%')
       AND file_url NOT LIKE "%localhost:94%"
       AND local_url IS NOT NULL
       AND CONCAT(display_id, CAST(date AS STRING)) IN (


### PR DESCRIPTION
- Remove accepting _unauthorized_ and _file does not exist_ as errors as they will be now logged as a `warning`
- Improve Video (using RC) reliability to exclude player error from RLS instance by filtering out `risemedialibrary-%` in file_url
- Remove specificity of event_details for a player error in Video RLS stats, unnecessary