### PR TITLE
Licensing reliability counting deleted displays

### DIFF
--- a/projects/client-side-events/datasets/Module_Events/licensing_reliability.bq
+++ b/projects/client-side-events/datasets/Module_Events/licensing_reliability.bq
@@ -30,8 +30,10 @@ watchdogModuleDownEventsCurrentVersion AS (
     date,
     display_id
   FROM
-    recentEventsCurrentVersion
+    recentEventsCurrentVersion r
+  LEFT JOIN `rise-core-log.coreData.deleted` d ON r.display_id = d.id 
   WHERE
+    (d.kind != "Display" OR d.kind IS NULL) AND
     event = "error" )
     
 SELECT


### PR DESCRIPTION
Removing deleted displays from licensing queries. Deleted displays don't get updates to display.json and will report errors.