### PR TITLE
Consider beta displays in reliability query

### DIFF
--- a/projects/client-side-events/datasets/ChromeOS_Player_Events/views/reliability.bq
+++ b/projects/client-side-events/datasets/ChromeOS_Player_Events/views/reliability.bq
@@ -16,7 +16,7 @@ recentEventsCurrentVersion AS (
     `client-side-events.ChromeOS_Player_Events.events`
   WHERE
     ts >= TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -5 DAY))
-    AND player_version = (SELECT version FROM latestVersion)),
+    AND ends_with(player_version, (SELECT version FROM latestVersion))),
       
 errorsCurrentVersion AS (
   SELECT


### PR DESCRIPTION
Using `ends_with` instead of `=` we'll be capturing displays during beta as well since their player_version is `beta_[version]`

Once in production this will still work, and beta displays won't be mixed into the results since they'll be on an older version.