### PR TITLE
Remove Image/Video RLS error conditionals

### DIFF
--- a/projects/client-side-events/datasets/Widget_Events/views/ImageFolderRLSStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/ImageFolderRLSStats.bq
@@ -35,10 +35,6 @@ SELECT * FROM (
       SELECT date, display_id FROM allDisplays
       WHERE event = "error"
       AND configuration = "storage folder (rls)"
-      AND (
-        event_details IN ('no connection', 'required modules unavailable', 'authorization error', 'folder does not exist') OR
-        (error_details IS NOT NULL AND file_url NOT LIKE "%localhost:94%" AND file_url NOT LIKE "https://storage-dot-rvaserver2.appspot.com%")
-      )
       AND CONCAT(display_id, CAST(date AS STRING)) IN
                 (
                   SELECT CONCAT(display_id, CAST(date AS STRING))

--- a/projects/client-side-events/datasets/Widget_Events/views/ImageRLSStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/ImageRLSStats.bq
@@ -35,10 +35,6 @@ SELECT * FROM (
       SELECT date, display_id FROM allDisplays
       WHERE event = "error"
       and configuration = "storage file (rls)"
-      AND (
-        event_details IN ('no connection', 'required modules unavailable') OR
-        (error_details IS NOT NULL AND file_url NOT LIKE "%localhost:94%" AND file_url NOT LIKE "https://storage-dot-rvaserver2.appspot.com%")
-      )
       AND CONCAT(display_id, CAST(date AS STRING)) IN
                 (
                   SELECT CONCAT(display_id, CAST(date AS STRING))

--- a/projects/client-side-events/datasets/Widget_Events/views/VideoFolderRLSStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/VideoFolderRLSStats.bq
@@ -35,8 +35,6 @@ SELECT * FROM (
       SELECT date, display_id FROM allDisplays
       WHERE event = "error"
       AND configuration = "storage folder (rls)"
-      AND (event_details IN ('no connection', 'required modules unavailable', 'folder does not exist') OR event_details LIKE "authorization error%" OR
-        (file_url NOT LIKE "%localhost:94%" AND file_url NOT LIKE "https://storage-dot-rvaserver2.appspot.com%"))
       AND CONCAT(display_id, CAST(date AS STRING)) IN
                 (
                   SELECT CONCAT(display_id, CAST(date AS STRING))
@@ -49,8 +47,6 @@ SELECT * FROM (
       SELECT date, display_id FROM allDisplays
       WHERE event = "player error"
       AND configuration = "storage folder (rls)"
-      AND file_url NOT LIKE "%localhost:94%"
-      AND local_url IS NOT NULL
       AND CONCAT(display_id, CAST(date AS STRING)) IN (
         SELECT CONCAT(display_id, CAST(date AS STRING))
         FROM allDisplays

--- a/projects/client-side-events/datasets/Widget_Events/views/VideoRLSStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/VideoRLSStats.bq
@@ -35,8 +35,6 @@ SELECT * FROM (
       SELECT date, display_id FROM allDisplays
       WHERE event = "error"
       AND configuration = "storage file (rls)"
-      AND (event_details IN ('no connection', 'required modules unavailable') OR
-        (file_url NOT LIKE "%localhost:94%" AND file_url NOT LIKE "https://storage-dot-rvaserver2.appspot.com%"))
       AND CONCAT(display_id, CAST(date AS STRING)) IN
                 (
                   SELECT CONCAT(display_id, CAST(date AS STRING))
@@ -49,8 +47,6 @@ SELECT * FROM (
       SELECT date, display_id FROM allDisplays
       WHERE event = "player error"
       AND configuration = "storage file (rls)"
-      AND file_url NOT LIKE "%localhost:94%"
-      AND local_url IS NOT NULL
       AND CONCAT(display_id, CAST(date AS STRING)) IN (
         SELECT CONCAT(display_id, CAST(date AS STRING))
         FROM allDisplays


### PR DESCRIPTION
- “configuration” column already filters events pertaining to RC
- These conditionals have been filtering some errors needed to be tracked