### PR TITLE
Revise ImageVideoReliability view and add top errors for non RLS

### DIFF
--- a/projects/client-side-events/datasets/Widget_Events/queries/ImageNonRLS_TopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/ImageNonRLS_TopErrorsByDay.bq
@@ -1,0 +1,24 @@
+#standardSQL
+
+WITH
+
+allDisplays AS (
+  SELECT DATE(ts) AS date, display_id, event, event_details, error_details, file_url, configuration
+  FROM `client-side-events.Widget_Events.image_events*`
+  WHERE _TABLE_SUFFIX = "20XXXXXX"
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+)
+
+SELECT COUNT(distinct display_id) as display_count, SUBSTR(event_details, 0, 200) AS details
+FROM allDisplays
+WHERE event = "error"
+AND configuration NOT LIKE "%rls%"
+AND event_details IS NOT NULL
+AND event_details IN ('rise storage error', 'rise cache error', 'storage api error')
+AND error_details != "The request failed with status code: 404"
+AND CONCAT(display_id, CAST(date AS STRING)) IN (
+    SELECT CONCAT(display_id, CAST(date AS STRING))
+    FROM allDisplays
+    WHERE (event = "configuration" AND event_details NOT LIKE "%rls%"))
+GROUP BY details
+ORDER BY display_count DESC

--- a/projects/client-side-events/datasets/Widget_Events/queries/VideoNonRLS_TopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/VideoNonRLS_TopErrorsByDay.bq
@@ -1,0 +1,53 @@
+#standardSQL
+
+WITH
+
+allDisplays AS (
+  SELECT DATE(ts) AS date, display_id, event, event_details, file_url, configuration, version
+  FROM `client-side-events.Widget_Events.video_v2_events*`
+  WHERE _TABLE_SUFFIX = "20XXXXXX"
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND (version="2.0.0" OR version="1.1.0")
+)
+
+SELECT COUNT(distinct display_id) as display_count, SUBSTR(event_details, 0, 200) AS details
+FROM (
+  SELECT date, display_id, event_details FROM allDisplays
+  WHERE event IN ("rise storage error","storage api error")
+  AND configuration NOT LIKE "%rls%"
+  AND CONCAT(display_id, CAST(date AS STRING)) IN
+            (
+              SELECT CONCAT(display_id, CAST(date AS STRING))
+              FROM allDisplays
+              WHERE (event = "configuration" AND event_details NOT LIKE "%rls%")
+            )
+
+  UNION ALL
+
+  SELECT date, display_id, event_details FROM allDisplays
+  WHERE event = "player error"
+  AND configuration NOT LIKE "%rls%"
+  AND (event_details = "video - Error loading media: File could not be played" OR event_details LIKE "%MEDIA_ERR%")
+  AND file_url NOT LIKE "risemedialibrary-%"
+  AND CONCAT(display_id, CAST(date AS STRING)) IN (
+    SELECT CONCAT(display_id, CAST(date AS STRING))
+    FROM allDisplays
+    WHERE (event = "configuration" AND event_details NOT LIKE "%rls%")
+  )
+
+  UNION ALL
+
+  SELECT date, display_id, event_details FROM allDisplays
+  WHERE event = "rise cache error"
+  AND configuration NOT LIKE "%rls%"
+  AND event_details != "The request failed with status code: 404"
+  AND event_details IS NOT NULL
+  AND CONCAT(display_id, CAST(date AS STRING)) IN (
+    SELECT CONCAT(display_id, CAST(date AS STRING))
+    FROM allDisplays
+    WHERE (event = "configuration" AND event_details NOT LIKE "%rls%")
+  )
+)
+
+GROUP BY details
+ORDER BY display_count DESC

--- a/projects/client-side-events/datasets/Widget_Events/views/ImageVideoReliability.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/ImageVideoReliability.bq
@@ -17,16 +17,17 @@ image_rls_folder AS
   WHERE STRING(TIMESTAMP(date)) BETWEEN FORMAT_DATE('%E4Y-%m-%d', DATE_ADD(CURRENT_DATE(), INTERVAL -7 DAY))
       AND FORMAT_DATE('%E4Y-%m-%d', CURRENT_DATE())
   AND total_count > 1 # avoids rogue tables that only have a value of 1 for total count
-ORDER BY date DESC
+  ORDER BY date DESC
 ),
 
-image_risecache AS
+image_non_rls AS
 (
-  SELECT usage_date, IFNULL(Reliability, 1) AS reliability
-  FROM `client-side-events.Aggregate_Tables.ImageDailyReliability`
-  WHERE STRING(TIMESTAMP(usage_date)) BETWEEN FORMAT_DATE('%E4Y-%m-%d', DATE_ADD(CURRENT_DATE(), INTERVAL -7 DAY))
+  SELECT date, ((total_count - failed_count)/total_count) as reliability
+  FROM `client-side-events.Aggregate_Tables.ImageNonRLSStats`
+  WHERE STRING(TIMESTAMP(date)) BETWEEN FORMAT_DATE('%E4Y-%m-%d', DATE_ADD(CURRENT_DATE(), INTERVAL -7 DAY))
       AND FORMAT_DATE('%E4Y-%m-%d', CURRENT_DATE())
-  AND usageCount > 1
+  AND total_count > 1 # avoids rogue tables that only have a value of 1 for total count
+  ORDER BY date DESC
 ),
 
 video_rls_single AS
@@ -49,30 +50,31 @@ video_rls_folder AS
   ORDER BY date DESC
 ),
 
-video_risecache AS
+video_non_rls AS
 (
-  SELECT usage_date, IFNULL(Reliability, 1) as reliability
-  FROM `client-side-events.Aggregate_Tables.VideoDailyReliability`
-  WHERE STRING(TIMESTAMP(usage_date)) BETWEEN FORMAT_DATE('%E4Y-%m-%d', DATE_ADD(CURRENT_DATE(), INTERVAL -7 DAY))
+  SELECT date, ((total_count - failed_count)/total_count) as reliability
+  FROM `client-side-events.Aggregate_Tables.VideoNonRLSStats`
+  WHERE STRING(TIMESTAMP(date)) BETWEEN FORMAT_DATE('%E4Y-%m-%d', DATE_ADD(CURRENT_DATE(), INTERVAL -7 DAY))
       AND FORMAT_DATE('%E4Y-%m-%d', CURRENT_DATE())
-  AND usageCount > 1
+  AND total_count > 1
+  ORDER BY date DESC
 )
 
-SELECT date, image_rls_single_r, image_rls_folder_r, image_risecache_r, video_rls_single_r, video_rls_folder_r, video_risecache_r
+SELECT date, image_rls_single_r, image_rls_folder_r, image_non_rls_r, video_rls_single_r, video_rls_folder_r, video_non_rls_r
 FROM (
   SELECT image_rls_single.date as date,
        image_rls_single.reliability as image_rls_single_r,
        image_rls_folder.reliability as image_rls_folder_r,
-       image_risecache.reliability as image_risecache_r,
+       image_non_rls.reliability as image_non_rls_r,
        video_rls_single.reliability as video_rls_single_r,
        video_rls_folder.reliability as video_rls_folder_r,
-       video_risecache.reliability as video_risecache_r
+       video_non_rls.reliability as video_non_rls_r
   FROM
     image_rls_single
   LEFT JOIN image_rls_folder ON image_rls_folder.date = image_rls_single.date
-  LEFT JOIN image_risecache ON DATE(TIMESTAMP(image_risecache.usage_date)) = image_rls_single.date
+  LEFT JOIN image_non_rls ON DATE(TIMESTAMP(image_non_rls.date)) = image_rls_single.date
   LEFT JOIN video_rls_single ON video_rls_single.date = image_rls_single.date
   LEFT JOIN video_rls_folder ON video_rls_folder.date = image_rls_single.date
-  LEFT JOIN video_risecache ON DATE(TIMESTAMP(video_risecache.usage_date)) = image_rls_single.date
+  LEFT JOIN video_non_rls ON DATE(TIMESTAMP(video_non_rls.date)) = image_rls_single.date
 )
 ORDER by date DESC


### PR DESCRIPTION
- Use new non RLS aggregate tables for ImageVideoReliability query
- Add top errors by day queries for Image and Video non RLS