### PR TITLE
Account for missing error conditionals for Image/Video Non RLS reliability

### DIFF
--- a/projects/client-side-events/datasets/Widget_Events/queries/ImageNonRLS_TopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/ImageNonRLS_TopErrorsByDay.bq
@@ -3,7 +3,7 @@
 WITH
 
 allDisplays AS (
-  SELECT DATE(ts) AS date, display_id, event, event_details, error_details, file_url, configuration
+  SELECT DATE(ts) AS date, display_id, event, event_details, IFNULL(error_details, "") as error_details, file_url, configuration
   FROM `client-side-events.Widget_Events.image_events*`
   WHERE _TABLE_SUFFIX = "20XXXXXX"
   AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
@@ -14,7 +14,7 @@ FROM allDisplays
 WHERE event = "error"
 AND configuration NOT LIKE "%rls%"
 AND event_details IS NOT NULL
-AND event_details IN ('rise storage error', 'rise cache error', 'storage api error')
+AND event_details IN ('rise storage error', 'rise cache error', 'storage api error', 'image load error', 'rise cache not running')
 AND error_details != "The request failed with status code: 404"
 AND CONCAT(display_id, CAST(date AS STRING)) IN (
     SELECT CONCAT(display_id, CAST(date AS STRING))

--- a/projects/client-side-events/datasets/Widget_Events/queries/VideoNonRLS_TopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/VideoNonRLS_TopErrorsByDay.bq
@@ -13,7 +13,7 @@ allDisplays AS (
 SELECT COUNT(distinct display_id) as display_count, SUBSTR(event_details, 0, 200) AS details
 FROM (
   SELECT date, display_id, event_details FROM allDisplays
-  WHERE event IN ("rise storage error","storage api error")
+  WHERE event IN ("rise storage error", "storage api error", "rise cache not running")
   AND configuration NOT LIKE "%rls%"
   AND CONCAT(display_id, CAST(date AS STRING)) IN
             (

--- a/projects/client-side-events/datasets/Widget_Events/views/ImageNonRLSStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/ImageNonRLSStats.bq
@@ -3,7 +3,7 @@
 WITH
 
 allDisplays AS (
-  SELECT DATE(ts) AS date, display_id, event, event_details, error_details, file_url, configuration
+  SELECT DATE(ts) AS date, display_id, event, event_details, IFNULL(error_details, "") as error_details, file_url, configuration
   FROM `client-side-events.Widget_Events.image_events*`
   WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
   AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
@@ -29,7 +29,7 @@ SELECT * FROM (
       WHERE event = "error"
       AND configuration NOT LIKE "%rls%"
       AND event_details IS NOT NULL
-      AND event_details IN ('rise storage error', 'rise cache error', 'storage api error')
+      AND event_details IN ('rise storage error', 'rise cache error', 'storage api error', 'image load error', 'rise cache not running')
       AND error_details != "The request failed with status code: 404"
       AND CONCAT(display_id, CAST(date AS STRING)) IN (
         SELECT CONCAT(display_id, CAST(date AS STRING))

--- a/projects/client-side-events/datasets/Widget_Events/views/VideoNonRLSStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/VideoNonRLSStats.bq
@@ -27,7 +27,7 @@ SELECT * FROM (
     SELECT date, COUNT(DISTINCT(display_id)) AS failed_count
     FROM (
       SELECT date, display_id FROM allDisplays
-      WHERE event IN ("rise storage error","storage api error")
+      WHERE event IN ("rise storage error", "storage api error", "rise cache not running")
       AND configuration NOT LIKE "%rls%"
       AND CONCAT(display_id, CAST(date AS STRING)) IN
           (


### PR DESCRIPTION
- `image load error` should be included to impact reliability
- `rise cache not running` has not been included for some time but should be as it helps to indicate displays having a problem