### PR TITLE
Include ChromeOS in Content reliability view/queries

### DIFF
--- a/projects/client-side-events/datasets/Widget_Events/queries/CalendarTopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/CalendarTopErrorsByDay.bq
@@ -2,26 +2,38 @@
 
 WITH
 
-allDisplays AS (
-  SELECT DATE(ts) AS date, display_id, event, event_details, error_details
-  FROM `client-side-events.Widget_Events.calendar_events*`
-  WHERE _TABLE_SUFFIX = "20XXXXXX"
-  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-  AND display_id IN (
-    SELECT DISTINCT(display_id)
+electronStableDisplays AS (
+  SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
       WHERE _TABLE_SUFFIX = "20XXXXXX"
       AND installer_version NOT LIKE "beta_%"
-      AND event = "install complete"
+),
+
+chromeOSStableDisplays AS (
+  SELECT DISTINCT(id)
+        FROM `client-side-events.ChromeOS_Player_Events.events`
+        WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
+        AND player_version NOT LIKE "beta_%"
+),
+
+allDisplays AS (
+  SELECT DATE(ts) AS date, *
+  FROM `client-side-events.Widget_Events.calendar_events*`
+  WHERE _TABLE_SUFFIX = "20XXXXXX"
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND (
+    display_id IN (SELECT * FROM electronStableDisplays) OR display_id IN (SELECT * FROM chromeOSStableDisplays)
   )
 )
 
 SELECT COUNT(distinct display_id) as display_count, SUBSTR(event_details, 0, 200) AS details, error_details
 FROM allDisplays
 WHERE event = "error"
+AND event_details NOT LIKE '%"code":-1%network error%'
 AND CONCAT(display_id, CAST(date AS STRING)) IN (
     SELECT CONCAT(display_id, CAST(date AS STRING))
     FROM allDisplays
-    WHERE (event = "configuration"))
+    WHERE event = "configuration"
+)
 GROUP BY details, error_details
 ORDER BY display_count DESC

--- a/projects/client-side-events/datasets/Widget_Events/queries/CalendarTopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/CalendarTopErrorsByDay.bq
@@ -5,6 +5,7 @@ WITH
 electronStableDisplays AS (
   SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
+      /* change date */
       WHERE _TABLE_SUFFIX = "20XXXXXX"
       AND installer_version NOT LIKE "beta_%"
 ),
@@ -12,13 +13,15 @@ electronStableDisplays AS (
 chromeOSStableDisplays AS (
   SELECT DISTINCT(id)
         FROM `client-side-events.ChromeOS_Player_Events.events`
-        WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
-        AND player_version NOT LIKE "beta_%"
+        /* uncomment and change dates */
+        /* WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
+        AND player_version NOT LIKE "beta_%" */
 ),
 
 allDisplays AS (
   SELECT DATE(ts) AS date, *
   FROM `client-side-events.Widget_Events.calendar_events*`
+  /* change date */
   WHERE _TABLE_SUFFIX = "20XXXXXX"
   AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
   AND (

--- a/projects/client-side-events/datasets/Widget_Events/queries/ImageFolderRLS_TopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/ImageFolderRLS_TopErrorsByDay.bq
@@ -5,6 +5,7 @@ WITH
 electronStableDisplays AS (
   SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
+      /* change date */
       WHERE _TABLE_SUFFIX = "20XXXXXX"
       AND installer_version NOT LIKE "beta_%"
 ),
@@ -12,13 +13,15 @@ electronStableDisplays AS (
 chromeOSStableDisplays AS (
   SELECT DISTINCT(id)
         FROM `client-side-events.ChromeOS_Player_Events.events`
-        WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
-        AND player_version NOT LIKE "beta_%"
+        /* uncomment and change dates */
+        /* WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
+        AND player_version NOT LIKE "beta_%" */
 ),
 
 allDisplays AS (
   SELECT DATE(ts) AS date, *
   FROM `client-side-events.Widget_Events.image_events*`
+  /* change date */
   WHERE _TABLE_SUFFIX = "20XXXXXX"
   AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
   AND (

--- a/projects/client-side-events/datasets/Widget_Events/queries/ImageFolderRLS_TopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/ImageFolderRLS_TopErrorsByDay.bq
@@ -2,17 +2,27 @@
 
 WITH
 
+electronStableDisplays AS (
+  SELECT DISTINCT(display_id)
+      FROM `client-side-events.Installer_Events.events*`
+      WHERE _TABLE_SUFFIX = "20XXXXXX"
+      AND installer_version NOT LIKE "beta_%"
+),
+
+chromeOSStableDisplays AS (
+  SELECT DISTINCT(id)
+        FROM `client-side-events.ChromeOS_Player_Events.events`
+        WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
+        AND player_version NOT LIKE "beta_%"
+),
+
 allDisplays AS (
-  SELECT DATE(ts) AS date, display_id, event, event_details, error_details, file_url,configuration
+  SELECT DATE(ts) AS date, *
   FROM `client-side-events.Widget_Events.image_events*`
   WHERE _TABLE_SUFFIX = "20XXXXXX"
   AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-  AND display_id IN (
-    SELECT DISTINCT(display_id)
-      FROM `client-side-events.Installer_Events.events*`
-        WHERE _TABLE_SUFFIX = "20XXXXXX"
-      AND installer_version NOT LIKE "beta_%"
-      AND event = "install complete"
+  AND (
+    display_id IN (SELECT * FROM electronStableDisplays) OR display_id IN (SELECT * FROM chromeOSStableDisplays)
   )
 )
 
@@ -23,6 +33,8 @@ AND configuration = "storage folder (rls)"
 AND CONCAT(display_id, CAST(date AS STRING)) IN (
     SELECT CONCAT(display_id, CAST(date AS STRING))
     FROM allDisplays
-    WHERE (event = "configuration" AND event_details = "storage folder (rls)"))
+    WHERE event = "configuration"
+    AND event_details = "storage folder (rls)"
+)
 GROUP BY details
 ORDER BY display_count DESC

--- a/projects/client-side-events/datasets/Widget_Events/queries/ImageSingleRLS_TopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/ImageSingleRLS_TopErrorsByDay.bq
@@ -2,17 +2,27 @@
 
 WITH
 
+electronStableDisplays AS (
+  SELECT DISTINCT(display_id)
+      FROM `client-side-events.Installer_Events.events*`
+      WHERE _TABLE_SUFFIX = "20XXXXXX"
+      AND installer_version NOT LIKE "beta_%"
+),
+
+chromeOSStableDisplays AS (
+  SELECT DISTINCT(id)
+        FROM `client-side-events.ChromeOS_Player_Events.events`
+        WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
+        AND player_version NOT LIKE "beta_%"
+),
+
 allDisplays AS (
-  SELECT DATE(ts) AS date, display_id, event, event_details, error_details, file_url, configuration
+  SELECT DATE(ts) AS date, *
   FROM `client-side-events.Widget_Events.image_events*`
   WHERE _TABLE_SUFFIX = "20XXXXXX"
   AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-  AND display_id IN (
-    SELECT DISTINCT(display_id)
-      FROM `client-side-events.Installer_Events.events*`
-        WHERE _TABLE_SUFFIX = "20XXXXXX"
-      AND installer_version NOT LIKE "beta_%"
-      AND event = "install complete"
+  AND (
+    display_id IN (SELECT * FROM electronStableDisplays) OR display_id IN (SELECT * FROM chromeOSStableDisplays)
   )
 )
 
@@ -23,6 +33,8 @@ AND configuration = "storage file (rls)"
 AND CONCAT(display_id, CAST(date AS STRING)) IN (
     SELECT CONCAT(display_id, CAST(date AS STRING))
     FROM allDisplays
-    WHERE (event = "configuration" AND event_details = "storage file (rls)"))
+    WHERE event = "configuration"
+    AND event_details = "storage file (rls)"
+)
 GROUP BY details
 ORDER BY display_count DESC

--- a/projects/client-side-events/datasets/Widget_Events/queries/ImageSingleRLS_TopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/ImageSingleRLS_TopErrorsByDay.bq
@@ -5,6 +5,7 @@ WITH
 electronStableDisplays AS (
   SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
+      /* change date */
       WHERE _TABLE_SUFFIX = "20XXXXXX"
       AND installer_version NOT LIKE "beta_%"
 ),
@@ -12,13 +13,15 @@ electronStableDisplays AS (
 chromeOSStableDisplays AS (
   SELECT DISTINCT(id)
         FROM `client-side-events.ChromeOS_Player_Events.events`
-        WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
-        AND player_version NOT LIKE "beta_%"
+        /* uncomment and change dates */
+        /* WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
+        AND player_version NOT LIKE "beta_%" */
 ),
 
 allDisplays AS (
   SELECT DATE(ts) AS date, *
   FROM `client-side-events.Widget_Events.image_events*`
+  /* change date */
   WHERE _TABLE_SUFFIX = "20XXXXXX"
   AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
   AND (

--- a/projects/client-side-events/datasets/Widget_Events/queries/RssTopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/RssTopErrorsByDay.bq
@@ -5,6 +5,7 @@ WITH
 electronStableDisplays AS (
   SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
+      /* change date */
       WHERE _TABLE_SUFFIX = "20XXXXXX"
       AND installer_version NOT LIKE "beta_%"
 ),
@@ -12,13 +13,15 @@ electronStableDisplays AS (
 chromeOSStableDisplays AS (
   SELECT DISTINCT(id)
         FROM `client-side-events.ChromeOS_Player_Events.events`
-        WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
-        AND player_version NOT LIKE "beta_%"
+        /* uncomment and change dates */
+        /* WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
+        AND player_version NOT LIKE "beta_%" */
 ),
 
 allDisplays AS (
   SELECT DATE(TIMESTAMP(ts)) AS date, *
   FROM `client-side-events.Widget_Events.rss_events*`
+  /* change date */
   WHERE _TABLE_SUFFIX = "20XXXXXX"
   AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
   AND (

--- a/projects/client-side-events/datasets/Widget_Events/queries/RssTopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/RssTopErrorsByDay.bq
@@ -2,17 +2,27 @@
 
 WITH
 
-allDisplays AS (
-  SELECT DATE(TIMESTAMP(ts)) AS date, display_id, event, event_details, error_details
-  FROM `client-side-events.Widget_Events.rss_events*`
-  WHERE _TABLE_SUFFIX = "20XXXXXX"
-  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-  AND display_id IN (
-    SELECT DISTINCT(display_id)
+electronStableDisplays AS (
+  SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
       WHERE _TABLE_SUFFIX = "20XXXXXX"
       AND installer_version NOT LIKE "beta_%"
-      AND event = "install complete"
+),
+
+chromeOSStableDisplays AS (
+  SELECT DISTINCT(id)
+        FROM `client-side-events.ChromeOS_Player_Events.events`
+        WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
+        AND player_version NOT LIKE "beta_%"
+),
+
+allDisplays AS (
+  SELECT DATE(TIMESTAMP(ts)) AS date, *
+  FROM `client-side-events.Widget_Events.rss_events*`
+  WHERE _TABLE_SUFFIX = "20XXXXXX"
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND (
+    display_id IN (SELECT * FROM electronStableDisplays) OR display_id IN (SELECT * FROM chromeOSStableDisplays)
   )
 )
 
@@ -20,10 +30,11 @@ SELECT COUNT(distinct display_id) as display_count, SUBSTR(event_details, 0, 200
 FROM allDisplays
 WHERE event = "error"
 AND event_details IS NOT NULL
-AND event_details IN ('rise rss error', 'canvas width is over the max size')
+AND event_details IN ("rise rss error")
 AND CONCAT(display_id, CAST(date AS STRING)) IN (
     SELECT CONCAT(display_id, CAST(date AS STRING))
     FROM allDisplays
-    WHERE (event = "configuration"))
+    WHERE event = "configuration"
+)
 GROUP BY details, error_details
 ORDER BY display_count DESC

--- a/projects/client-side-events/datasets/Widget_Events/queries/SpreadsheetTopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/SpreadsheetTopErrorsByDay.bq
@@ -2,17 +2,27 @@
 
 WITH
 
-allDisplays AS (
-  SELECT DATE(ts) AS date, display_id, event, event_details, error_details
-  FROM `client-side-events.Widget_Events.spreadsheet_events*`
-  WHERE _TABLE_SUFFIX = "20XXXXXX"
-  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-  AND display_id IN (
-    SELECT DISTINCT(display_id)
+electronStableDisplays AS (
+  SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
       WHERE _TABLE_SUFFIX = "20XXXXXX"
       AND installer_version NOT LIKE "beta_%"
-      AND event = "install complete"
+),
+
+chromeOSStableDisplays AS (
+  SELECT DISTINCT(id)
+        FROM `client-side-events.ChromeOS_Player_Events.events`
+        WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
+        AND player_version NOT LIKE "beta_%"
+),
+
+allDisplays AS (
+  SELECT DATE(TIMESTAMP(ts)) AS date, *
+  FROM `client-side-events.Widget_Events.spreadsheet_events*`
+  WHERE _TABLE_SUFFIX = "20XXXXXX"
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND (
+    display_id IN (SELECT * FROM electronStableDisplays) OR display_id IN (SELECT * FROM chromeOSStableDisplays)
   )
 )
 
@@ -27,6 +37,7 @@ AND error_details NOT LIKE "%code: 0%"
 AND CONCAT(display_id, CAST(date AS STRING)) IN (
     SELECT CONCAT(display_id, CAST(date AS STRING))
     FROM allDisplays
-    WHERE (event = "configuration"))
+    WHERE event = "configuration"
+)
 GROUP BY details, error_details
 ORDER BY display_count DESC

--- a/projects/client-side-events/datasets/Widget_Events/queries/SpreadsheetTopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/SpreadsheetTopErrorsByDay.bq
@@ -5,6 +5,7 @@ WITH
 electronStableDisplays AS (
   SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
+      /* change date */
       WHERE _TABLE_SUFFIX = "20XXXXXX"
       AND installer_version NOT LIKE "beta_%"
 ),
@@ -12,13 +13,15 @@ electronStableDisplays AS (
 chromeOSStableDisplays AS (
   SELECT DISTINCT(id)
         FROM `client-side-events.ChromeOS_Player_Events.events`
-        WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
-        AND player_version NOT LIKE "beta_%"
+        /* uncomment and change dates */
+        /* WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
+        AND player_version NOT LIKE "beta_%" */
 ),
 
 allDisplays AS (
-  SELECT DATE(TIMESTAMP(ts)) AS date, *
+  SELECT DATE(ts) AS date, *
   FROM `client-side-events.Widget_Events.spreadsheet_events*`
+  /* change date */
   WHERE _TABLE_SUFFIX = "20XXXXXX"
   AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
   AND (

--- a/projects/client-side-events/datasets/Widget_Events/queries/TextTopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/TextTopErrorsByDay.bq
@@ -2,17 +2,27 @@
 
 WITH
 
-allDisplays AS (
-  SELECT DATE(TIMESTAMP(ts)) AS date, display_id, event, event_details, error_details
-  FROM `client-side-events.Widget_Events.text_events*`
-  WHERE _TABLE_SUFFIX = "20XXXXXX"
-  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-  AND display_id IN (
-    SELECT DISTINCT(display_id)
+electronStableDisplays AS (
+  SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
       WHERE _TABLE_SUFFIX = "20XXXXXX"
       AND installer_version NOT LIKE "beta_%"
-      AND event = "install complete"
+),
+
+chromeOSStableDisplays AS (
+  SELECT DISTINCT(id)
+        FROM `client-side-events.ChromeOS_Player_Events.events`
+        WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
+        AND player_version NOT LIKE "beta_%"
+),
+
+allDisplays AS (
+  SELECT DATE(TIMESTAMP(ts)) AS date, *
+  FROM `client-side-events.Widget_Events.text_events*`
+  WHERE _TABLE_SUFFIX = "20XXXXXX"
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND (
+    display_id IN (SELECT * FROM electronStableDisplays) OR display_id IN (SELECT * FROM chromeOSStableDisplays)
   )
 )
 

--- a/projects/client-side-events/datasets/Widget_Events/queries/TextTopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/TextTopErrorsByDay.bq
@@ -5,6 +5,7 @@ WITH
 electronStableDisplays AS (
   SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
+      /* change date */
       WHERE _TABLE_SUFFIX = "20XXXXXX"
       AND installer_version NOT LIKE "beta_%"
 ),
@@ -12,13 +13,15 @@ electronStableDisplays AS (
 chromeOSStableDisplays AS (
   SELECT DISTINCT(id)
         FROM `client-side-events.ChromeOS_Player_Events.events`
-        WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
-        AND player_version NOT LIKE "beta_%"
+        /* uncomment and change dates */
+        /* WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
+        AND player_version NOT LIKE "beta_%" */
 ),
 
 allDisplays AS (
   SELECT DATE(TIMESTAMP(ts)) AS date, *
   FROM `client-side-events.Widget_Events.text_events*`
+    /* change date */
   WHERE _TABLE_SUFFIX = "20XXXXXX"
   AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
   AND (

--- a/projects/client-side-events/datasets/Widget_Events/queries/VideoFolderRLS_TopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/VideoFolderRLS_TopErrorsByDay.bq
@@ -2,17 +2,27 @@
 
 WITH
 
-allDisplays AS (
-  SELECT DATE(ts) AS date, display_id, event, event_details, file_url, local_url, configuration
-  FROM `client-side-events.Widget_Events.video_v2_events*`
-  WHERE _TABLE_SUFFIX = "20XXXXXX"
-  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-  AND display_id IN (
-    SELECT DISTINCT(display_id)
+electronStableDisplays AS (
+  SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
       WHERE _TABLE_SUFFIX = "20XXXXXX"
       AND installer_version NOT LIKE "beta_%"
-      AND event = "install complete"
+),
+
+chromeOSStableDisplays AS (
+  SELECT DISTINCT(id)
+        FROM `client-side-events.ChromeOS_Player_Events.events`
+        WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
+        AND player_version NOT LIKE "beta_%"
+),
+
+allDisplays AS (
+  SELECT DATE(ts) AS date, *
+  FROM `client-side-events.Widget_Events.video_v2_events*`
+  WHERE _TABLE_SUFFIX = "20XXXXXX"
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND (
+    display_id IN (SELECT * FROM electronStableDisplays) OR display_id IN (SELECT * FROM chromeOSStableDisplays)
   )
 )
 
@@ -25,7 +35,8 @@ FROM (
             (
               SELECT CONCAT(display_id, CAST(date AS STRING))
               FROM allDisplays
-              WHERE (event = "configuration" AND event_details = "storage folder (rls)")
+              WHERE event = "configuration"
+              AND event_details = "storage folder (rls)"
             )
 
   UNION ALL
@@ -36,7 +47,8 @@ FROM (
   AND CONCAT(display_id, CAST(date AS STRING)) IN (
     SELECT CONCAT(display_id, CAST(date AS STRING))
     FROM allDisplays
-    WHERE (event = "configuration" AND event_details = "storage folder (rls)")
+    WHERE event = "configuration"
+    AND event_details = "storage folder (rls)"
   )
 )
 

--- a/projects/client-side-events/datasets/Widget_Events/queries/VideoFolderRLS_TopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/VideoFolderRLS_TopErrorsByDay.bq
@@ -5,6 +5,7 @@ WITH
 electronStableDisplays AS (
   SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
+      /* change date */
       WHERE _TABLE_SUFFIX = "20XXXXXX"
       AND installer_version NOT LIKE "beta_%"
 ),
@@ -12,13 +13,15 @@ electronStableDisplays AS (
 chromeOSStableDisplays AS (
   SELECT DISTINCT(id)
         FROM `client-side-events.ChromeOS_Player_Events.events`
-        WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
-        AND player_version NOT LIKE "beta_%"
+        /* uncomment and change dates */
+        /* WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
+        AND player_version NOT LIKE "beta_%" */
 ),
 
 allDisplays AS (
   SELECT DATE(ts) AS date, *
   FROM `client-side-events.Widget_Events.video_v2_events*`
+  /* change date */
   WHERE _TABLE_SUFFIX = "20XXXXXX"
   AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
   AND (

--- a/projects/client-side-events/datasets/Widget_Events/queries/VideoSingleRLS_TopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/VideoSingleRLS_TopErrorsByDay.bq
@@ -5,6 +5,7 @@ WITH
 electronStableDisplays AS (
   SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
+      /* change date */
       WHERE _TABLE_SUFFIX = "20XXXXXX"
       AND installer_version NOT LIKE "beta_%"
 ),
@@ -12,13 +13,15 @@ electronStableDisplays AS (
 chromeOSStableDisplays AS (
   SELECT DISTINCT(id)
         FROM `client-side-events.ChromeOS_Player_Events.events`
-        WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
-        AND player_version NOT LIKE "beta_%"
+        /* uncomment and change dates */
+        /* WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
+        AND player_version NOT LIKE "beta_%" */
 ),
 
 allDisplays AS (
   SELECT DATE(ts) AS date, *
   FROM `client-side-events.Widget_Events.video_v2_events*`
+  /* change date */
   WHERE _TABLE_SUFFIX = "20XXXXXX"
   AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
   AND (

--- a/projects/client-side-events/datasets/Widget_Events/queries/VideoSingleRLS_TopErrorsByDay.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/VideoSingleRLS_TopErrorsByDay.bq
@@ -2,17 +2,27 @@
 
 WITH
 
-allDisplays AS (
-  SELECT DATE(ts) AS date, display_id, event, event_details, file_url, local_url, configuration
-  FROM `client-side-events.Widget_Events.video_v2_events*`
-  WHERE _TABLE_SUFFIX = "20XXXXXX"
-  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-  AND display_id IN (
-    SELECT DISTINCT(display_id)
+electronStableDisplays AS (
+  SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
       WHERE _TABLE_SUFFIX = "20XXXXXX"
       AND installer_version NOT LIKE "beta_%"
-      AND event = "install complete"
+),
+
+chromeOSStableDisplays AS (
+  SELECT DISTINCT(id)
+        FROM `client-side-events.ChromeOS_Player_Events.events`
+        WHERE ts >= "20XX-XX-XX 00:00:00" AND ts < "20XX-XX-XX 00:00:00"
+        AND player_version NOT LIKE "beta_%"
+),
+
+allDisplays AS (
+  SELECT DATE(ts) AS date, *
+  FROM `client-side-events.Widget_Events.video_v2_events*`
+  WHERE _TABLE_SUFFIX = "20XXXXXX"
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND (
+    display_id IN (SELECT * FROM electronStableDisplays) OR display_id IN (SELECT * FROM chromeOSStableDisplays)
   )
 )
 
@@ -25,7 +35,8 @@ FROM (
             (
               SELECT CONCAT(display_id, CAST(date AS STRING))
               FROM allDisplays
-              WHERE (event = "configuration" AND event_details = "storage file (rls)")
+              WHERE event = "configuration"
+              AND event_details = "storage file (rls)"
             )
 
   UNION ALL
@@ -36,7 +47,8 @@ FROM (
   AND CONCAT(display_id, CAST(date AS STRING)) IN (
     SELECT CONCAT(display_id, CAST(date AS STRING))
     FROM allDisplays
-    WHERE (event = "configuration" AND event_details = "storage file (rls)")
+    WHERE event = "configuration"
+    AND event_details = "storage file (rls)"
   )
 )
 

--- a/projects/client-side-events/datasets/Widget_Events/views/CalendarStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/CalendarStats.bq
@@ -2,19 +2,30 @@
 
 WITH
 
-allDisplays AS (
-  SELECT DATE(ts) AS date, display_id, event
-  FROM `client-side-events.Widget_Events.calendar_events*`
-  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
-  AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
-  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-  AND display_id IN (
-    SELECT DISTINCT(display_id)
+electronStableDisplays AS (
+  SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
       WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
       AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
       AND installer_version NOT LIKE "beta_%"
-      AND event = "install complete"
+),
+
+chromeOSStableDisplays AS (
+  SELECT DISTINCT(id)
+        FROM `client-side-events.ChromeOS_Player_Events.events`
+        WHERE ts BETWEEN TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+        AND TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
+        AND player_version NOT LIKE "beta_%"
+),
+
+allDisplays AS (
+  SELECT DATE(ts) AS date, *
+  FROM `client-side-events.Widget_Events.calendar_events*`
+  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+  AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND (
+    display_id IN (SELECT * FROM electronStableDisplays) OR display_id IN (SELECT * FROM chromeOSStableDisplays)
   )
 )
 
@@ -26,7 +37,7 @@ SELECT * FROM (
   FROM (
     SELECT date, COUNT(DISTINCT(display_id)) AS total_count
     FROM allDisplays
-    WHERE (event = "configuration")
+    WHERE event = "configuration"
     GROUP BY date
   ) a
   LEFT JOIN (
@@ -34,11 +45,12 @@ SELECT * FROM (
     FROM (
       SELECT date, display_id FROM allDisplays
       WHERE event = "error"
+      AND event_details NOT LIKE '%"code":-1%network error%'
       AND CONCAT(display_id, CAST(date AS STRING)) IN
                 (
                   SELECT CONCAT(display_id, CAST(date AS STRING))
                   FROM allDisplays
-                  WHERE (event = "configuration")
+                  WHERE event = "configuration"
                 )
     )
     GROUP BY date

--- a/projects/client-side-events/datasets/Widget_Events/views/ImageFolderRLSStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/ImageFolderRLSStats.bq
@@ -2,19 +2,30 @@
 
 WITH
 
-allDisplays AS (
-  SELECT DATE(ts) AS date, display_id, event, event_details, error_details, file_url, configuration
-  FROM `client-side-events.Widget_Events.image_events*`
-  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
-  AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
-  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-  AND display_id IN (
-    SELECT DISTINCT(display_id)
+electronStableDisplays AS (
+  SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
       WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
       AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
       AND installer_version NOT LIKE "beta_%"
-      AND event = "install complete"
+),
+
+chromeOSStableDisplays AS (
+  SELECT DISTINCT(id)
+        FROM `client-side-events.ChromeOS_Player_Events.events`
+        WHERE ts BETWEEN TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+        AND TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
+        AND player_version NOT LIKE "beta_%"
+),
+
+allDisplays AS (
+  SELECT DATE(ts) AS date, *
+  FROM `client-side-events.Widget_Events.image_events*`
+  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+  AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND (
+    display_id IN (SELECT * FROM electronStableDisplays) OR display_id IN (SELECT * FROM chromeOSStableDisplays)
   )
 )
 
@@ -26,7 +37,8 @@ SELECT * FROM (
   FROM (
     SELECT date, COUNT(DISTINCT(display_id)) AS total_count
     FROM allDisplays
-    WHERE (event = "configuration" AND event_details = "storage folder (rls)")
+    WHERE event = "configuration"
+    AND event_details = "storage folder (rls)"
     GROUP BY date
   ) a
   LEFT JOIN (
@@ -39,7 +51,8 @@ SELECT * FROM (
                 (
                   SELECT CONCAT(display_id, CAST(date AS STRING))
                   FROM allDisplays
-                  WHERE (event = "configuration" AND event_details = "storage folder (rls)")
+                  WHERE event = "configuration"
+                  AND event_details = "storage folder (rls)"
                 )
     )
     GROUP BY date

--- a/projects/client-side-events/datasets/Widget_Events/views/ImageRLSStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/ImageRLSStats.bq
@@ -2,19 +2,30 @@
 
 WITH
 
-allDisplays AS (
-  SELECT DATE(ts) AS date, display_id, event, event_details, error_details, file_url, configuration
-  FROM `client-side-events.Widget_Events.image_events*`
-  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
-  AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
-  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-  AND display_id IN (
-    SELECT DISTINCT(display_id)
+electronStableDisplays AS (
+  SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
       WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
       AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
       AND installer_version NOT LIKE "beta_%"
-      AND event = "install complete"
+),
+
+chromeOSStableDisplays AS (
+  SELECT DISTINCT(id)
+        FROM `client-side-events.ChromeOS_Player_Events.events`
+        WHERE ts BETWEEN TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+        AND TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
+        AND player_version NOT LIKE "beta_%"
+),
+
+allDisplays AS (
+  SELECT DATE(ts) AS date, *
+  FROM `client-side-events.Widget_Events.image_events*`
+  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+  AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND (
+    display_id IN (SELECT * FROM electronStableDisplays) OR display_id IN (SELECT * FROM chromeOSStableDisplays)
   )
 )
 
@@ -26,7 +37,8 @@ SELECT * FROM (
   FROM (
     SELECT date, COUNT(DISTINCT(display_id)) AS total_count
     FROM allDisplays
-    WHERE (event = "configuration" AND event_details = "storage file (rls)")
+    WHERE event = "configuration"
+    AND event_details = "storage file (rls)"
     GROUP BY date
   ) a
   LEFT JOIN (
@@ -39,7 +51,8 @@ SELECT * FROM (
                 (
                   SELECT CONCAT(display_id, CAST(date AS STRING))
                   FROM allDisplays
-                  WHERE (event = "configuration" AND event_details = "storage file (rls)")
+                  WHERE event = "configuration"
+                  AND event_details = "storage file (rls)"
                 )
     )
     GROUP BY date

--- a/projects/client-side-events/datasets/Widget_Events/views/RssDailyReliability.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/RssDailyReliability.bq
@@ -1,38 +1,79 @@
-SELECT * FROM
-(
-  SELECT INTEGER(usageCount) as usageCount,
-         IFNULL(INTEGER(errorCount),0) as errorCount,
-         ((usageCount-IFNULL(INTEGER(errorCount),0))/usageCount) as Reliability,
-         usage.date as usage_date,
-         IFNULL(INTEGER(componentUsage.componentUsageCount),0) as componentUsageCount
-    FROM
-      (SELECT COUNT(DISTINCT display_id) as usageCount, Date(ts) AS date
-        FROM TABLE_DATE_RANGE(Widget_Events.rss_events, DATE_ADD(CURRENT_TIMESTAMP(), -3, 'DAY'), CURRENT_TIMESTAMP())
-          WHERE event = 'configuration'
-          AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-          GROUP BY date
-      ) AS usage
-    OUTER JOIN EACH
-      (SELECT COUNT(DISTINCT display_id) as errorCount, Date(ts) AS date
-        FROM TABLE_DATE_RANGE(Widget_Events.rss_events, DATE_ADD(CURRENT_TIMESTAMP(), -3, 'DAY'), CURRENT_TIMESTAMP())
-        WHERE event="error"
-        AND event_details IS NOT NULL
-        AND event_details IN ('rise rss error', 'canvas width is over the max size')
-        AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-        GROUP BY date
-      ) AS error
-    ON usage.date=error.date
-    OUTER JOIN EACH
-      (SELECT COUNT(DISTINCT display_id) as componentUsageCount, Date(ts) as date
-        FROM TABLE_DATE_RANGE(Widget_Events.component_rss_events, DATE_ADD(CURRENT_TIMESTAMP(), -3, 'DAY'), CURRENT_TIMESTAMP())
-        WHERE usage_type = 'standalone'
-        GROUP BY date
-      ) AS componentUsage
-    ON usage.date=componentUsage.date
-  ORDER BY usage.date
+#standardSQL
+
+WITH
+
+electronStableDisplays AS (
+  SELECT DISTINCT(display_id)
+      FROM `client-side-events.Installer_Events.events*`
+      WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+      AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+      AND installer_version NOT LIKE "beta_%"
 ),
-(
-  SELECT * FROM [client-side-events:Aggregate_Tables.RssDailyReliability]
-  WHERE usage_date < DATE(DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY"))
+
+chromeOSStableDisplays AS (
+  SELECT DISTINCT(id)
+        FROM `client-side-events.ChromeOS_Player_Events.events`
+        WHERE ts BETWEEN TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+        AND TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
+        AND player_version NOT LIKE "beta_%"
+),
+
+allDisplays AS (
+  SELECT DATE(TIMESTAMP(ts)) AS date, *
+  FROM `client-side-events.Widget_Events.rss_events*`
+  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+  AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND (
+    display_id IN (SELECT * FROM electronStableDisplays) OR display_id IN (SELECT * FROM chromeOSStableDisplays)
+  )
+)
+
+SELECT * FROM (
+  SELECT
+     usageCount,
+     IFNULL(errorCount,0) as errorCount,
+     ((usageCount-IFNULL(errorCount,0))/usageCount) as Reliability,
+     CAST(usage.date as String) as usage_date,
+     IFNULL(componentUsage.componentUsageCount,0) as componentUsageCount
+  FROM (
+    SELECT COUNT(DISTINCT display_id) as usageCount, date
+    FROM allDisplays
+    WHERE event = "configuration"
+    GROUP BY date
+  ) AS usage
+  LEFT JOIN (
+    SELECT COUNT(DISTINCT display_id) as errorCount, date
+    FROM (
+        SELECT display_id, date FROM allDisplays
+        WHERE event = "error"
+        AND event_details IS NOT NULL
+        AND event_details IN ("rise rss error")
+        AND CONCAT(display_id, CAST(date AS STRING)) IN
+            (
+              SELECT CONCAT(display_id, CAST(date AS STRING))
+              FROM allDisplays
+              WHERE event = "configuration"
+            )
+    )
+    GROUP BY date
+  ) AS error
+  ON usage.date=error.date
+
+  LEFT JOIN (
+    SELECT COUNT(DISTINCT display_id) as componentUsageCount, Date(ts) as date
+    FROM `client-side-events.Widget_Events.component_rss_events*`
+    WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+    AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+    AND usage_type = 'standalone'
+    GROUP BY date
+  ) AS componentUsage
+  ON usage.date=componentUsage.date
+
+  UNION ALL
+
+  SELECT usageCount, errorCount, Reliability, usage_date, componentUsageCount
+  FROM `client-side-events.Aggregate_Tables.RssDailyReliability`
+  WHERE DATE(TIMESTAMP(usage_date)) < DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY)
 )
 ORDER BY usage_date DESC

--- a/projects/client-side-events/datasets/Widget_Events/views/SpreadsheetDailyReliability.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/SpreadsheetDailyReliability.bq
@@ -1,42 +1,82 @@
-SELECT * FROM
-(
-  SELECT INTEGER(usageCount) as usageCount,
-         IFNULL(INTEGER(errorCount),0) as errorCount,
-         ((usageCount-IFNULL(INTEGER(errorCount),0))/usageCount) as Reliability,
-         usage.date as usage_date,
-         IFNULL(INTEGER(componentUsage.componentUsageCount),0) as componentUsageCount
-    FROM
-      (SELECT COUNT(DISTINCT display_id) as usageCount, Date(ts) AS date
-        FROM TABLE_DATE_RANGE(Widget_Events.spreadsheet_events, DATE_ADD(CURRENT_TIMESTAMP(), -3, 'DAY'), CURRENT_TIMESTAMP())
-          WHERE event = 'configuration'
-          AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-          GROUP BY date
-      ) usage
-    OUTER JOIN EACH
-      (SELECT COUNT(DISTINCT display_id) as errorCount, Date(ts) AS date
-        FROM TABLE_DATE_RANGE(Widget_Events.spreadsheet_events, DATE_ADD(CURRENT_TIMESTAMP(), -3, 'DAY'), CURRENT_TIMESTAMP())
-        WHERE event = 'error'
-        AND event_details != 'spreadsheet not published'
-        AND NOT error_details CONTAINS "400"
-        //403 results when spreadsheet is not public with link. We show msg in widget & settings. Nothing more we can do
-        AND NOT error_details CONTAINS "403"
-        AND NOT error_details CONTAINS "404"
-        AND NOT error_details CONTAINS "code: 0"
-        AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-        GROUP BY date
-      ) AS error
-    ON usage.date=error.date
-    OUTER JOIN EACH
-      (SELECT COUNT(DISTINCT display_id) as componentUsageCount, Date(ts) as date
-        FROM TABLE_DATE_RANGE(Widget_Events.component_sheet_events, DATE_ADD(CURRENT_TIMESTAMP(), -3, 'DAY'), CURRENT_TIMESTAMP())
-        WHERE usage_type = 'standalone'
-        GROUP BY date
-      ) componentUsage
-    ON usage.date=componentUsage.date
-  ORDER BY usage.date
+#standardSQL
+
+WITH
+
+electronStableDisplays AS (
+  SELECT DISTINCT(display_id)
+      FROM `client-side-events.Installer_Events.events*`
+      WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+      AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+      AND installer_version NOT LIKE "beta_%"
 ),
-(
-  SELECT * from[client-side-events:Aggregate_Tables.SpreadsheetDailyReliability]
-    WHERE usage_date < DATE(DATE_ADD(CURRENT_TIMESTAMP(), -3, "DAY"))
+
+chromeOSStableDisplays AS (
+  SELECT DISTINCT(id)
+        FROM `client-side-events.ChromeOS_Player_Events.events`
+        WHERE ts BETWEEN TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+        AND TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
+        AND player_version NOT LIKE "beta_%"
+),
+
+allDisplays AS (
+  SELECT DATE(ts) AS date, *
+  FROM `client-side-events.Widget_Events.spreadsheet_events*`
+  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+  AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND (
+    display_id IN (SELECT * FROM electronStableDisplays) OR display_id IN (SELECT * FROM chromeOSStableDisplays)
+  )
+)
+
+SELECT * FROM (
+  SELECT
+     usageCount,
+     IFNULL(errorCount,0) as errorCount,
+     ((usageCount-IFNULL(errorCount,0))/usageCount) as Reliability,
+     CAST(usage.date as String) as usage_date,
+     IFNULL(componentUsage.componentUsageCount,0) as componentUsageCount
+  FROM (
+    SELECT COUNT(DISTINCT display_id) as usageCount, date
+    FROM allDisplays
+    WHERE event = "configuration"
+    GROUP BY date
+  ) AS usage
+  LEFT JOIN (
+    SELECT COUNT(DISTINCT display_id) as errorCount, date
+    FROM (
+      SELECT display_id, date FROM allDisplays
+      WHERE event = "error"
+      AND event_details != "spreadsheet not published"
+      AND error_details NOT LIKE "%400%"
+      AND error_details NOT LIKE "%403%"
+      AND error_details NOT LIKE "%404%"
+      AND error_details NOT LIKE "%code: 0%"
+      AND CONCAT(display_id, CAST(date AS STRING)) IN
+          (
+            SELECT CONCAT(display_id, CAST(date AS STRING))
+            FROM allDisplays
+            WHERE event = "configuration"
+          )
+    )
+    GROUP BY date
+  ) AS error
+  ON usage.date=error.date
+
+  LEFT JOIN (
+      SELECT COUNT(DISTINCT display_id) as componentUsageCount, Date(ts) as date
+      FROM `client-side-events.Widget_Events.component_sheet_events*`
+      WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+      AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+      AND usage_type = 'standalone'
+      GROUP BY date
+  ) AS componentUsage
+  ON usage.date=componentUsage.date
+
+  UNION ALL
+
+  SELECT usageCount, errorCount, Reliability, usage_date, componentUsageCount
+  FROM `client-side-events.Aggregate_Tables.SpreadsheetDailyReliability`
+  WHERE DATE(TIMESTAMP(usage_date)) < DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY)
 )
 ORDER BY usage_date DESC

--- a/projects/client-side-events/datasets/Widget_Events/views/TextDailyReliability.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/TextDailyReliability.bq
@@ -1,3 +1,74 @@
+#standardSQL
+
+WITH
+
+electronStableDisplays AS (
+  SELECT DISTINCT(display_id)
+      FROM `client-side-events.Installer_Events.events*`
+      WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+      AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+      AND installer_version NOT LIKE "beta_%"
+),
+
+chromeOSStableDisplays AS (
+  SELECT DISTINCT(id)
+        FROM `client-side-events.ChromeOS_Player_Events.events`
+        WHERE ts BETWEEN TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+        AND TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
+        AND player_version NOT LIKE "beta_%"
+),
+
+allDisplays AS (
+  SELECT DATE(TIMESTAMP(ts)) AS date, *
+  FROM `client-side-events.Widget_Events.text_events*`
+  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+  AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND (
+    display_id IN (SELECT * FROM electronStableDisplays) OR display_id IN (SELECT * FROM chromeOSStableDisplays)
+  )
+)
+
+SELECT * FROM (
+  SELECT
+     usageCount,
+     IFNULL(errorCount,0) as errorCount,
+     ((usageCount-IFNULL(errorCount,0))/usageCount) as Reliability,
+     CAST(usage.date as String) as usage_date
+  FROM (
+    SELECT COUNT(DISTINCT display_id) as usageCount, date
+    FROM allDisplays
+    WHERE event = "configuration"
+    GROUP BY date
+  ) AS usage
+  LEFT JOIN (
+    SELECT COUNT(DISTINCT display_id) as errorCount, date
+    FROM (
+        SELECT display_id, date FROM allDisplays
+        WHERE event = "error"
+        AND CONCAT(display_id, CAST(date AS STRING)) IN
+            (
+              SELECT CONCAT(display_id, CAST(date AS STRING))
+              FROM allDisplays
+              WHERE event = "configuration"
+            )
+    )
+    GROUP BY date
+  ) AS error
+  ON usage.date=error.date
+
+  UNION ALL
+
+  SELECT usageCount, errorCount, Reliability, usage_date
+  FROM `client-side-events.Aggregate_Tables.TextDailyReliability`
+  WHERE DATE(TIMESTAMP(usage_date)) < DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY)
+)
+ORDER BY usage_date DESC
+
+
+
+
+
 SELECT * FROM
 (
   SELECT INTEGER(usageCount) as usageCount,

--- a/projects/client-side-events/datasets/Widget_Events/views/VideoFolderRLSStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/VideoFolderRLSStats.bq
@@ -2,19 +2,30 @@
 
 WITH
 
-allDisplays AS (
-  SELECT DATE(ts) AS date, display_id, event, event_details, file_url, local_url, configuration
-  FROM `client-side-events.Widget_Events.video_v2_events*`
-  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
-  AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
-  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-  AND display_id IN (
-    SELECT DISTINCT(display_id)
+electronStableDisplays AS (
+  SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
       WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
       AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
       AND installer_version NOT LIKE "beta_%"
-      AND event = "install complete"
+),
+
+chromeOSStableDisplays AS (
+  SELECT DISTINCT(id)
+        FROM `client-side-events.ChromeOS_Player_Events.events`
+        WHERE ts BETWEEN TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+        AND TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
+        AND player_version NOT LIKE "beta_%"
+),
+
+allDisplays AS (
+  SELECT DATE(ts) AS date, *
+  FROM `client-side-events.Widget_Events.video_v2_events*`
+  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+  AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND (
+    display_id IN (SELECT * FROM electronStableDisplays) OR display_id IN (SELECT * FROM chromeOSStableDisplays)
   )
 )
 
@@ -26,7 +37,8 @@ SELECT * FROM (
   FROM (
     SELECT date, COUNT(DISTINCT(display_id)) AS total_count
     FROM allDisplays
-    WHERE (event = "configuration" AND event_details = "storage folder (rls)")
+    WHERE event = "configuration"
+    AND event_details = "storage folder (rls)"
     GROUP BY date
   ) a
   LEFT JOIN (
@@ -39,7 +51,8 @@ SELECT * FROM (
                 (
                   SELECT CONCAT(display_id, CAST(date AS STRING))
                   FROM allDisplays
-                  WHERE (event = "configuration" AND event_details = "storage folder (rls)")
+                  WHERE event = "configuration"
+                  AND event_details = "storage folder (rls)"
                 )
 
       UNION ALL
@@ -50,7 +63,8 @@ SELECT * FROM (
       AND CONCAT(display_id, CAST(date AS STRING)) IN (
         SELECT CONCAT(display_id, CAST(date AS STRING))
         FROM allDisplays
-        WHERE (event = "configuration" AND event_details = "storage folder (rls)")
+        WHERE event = "configuration"
+        AND event_details = "storage folder (rls)"
       )
     )
 

--- a/projects/client-side-events/datasets/Widget_Events/views/VideoRLSStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/views/VideoRLSStats.bq
@@ -2,19 +2,30 @@
 
 WITH
 
-allDisplays AS (
-  SELECT DATE(ts) AS date, display_id, event, event_details, file_url, local_url, configuration
-  FROM `client-side-events.Widget_Events.video_v2_events*`
-  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
-  AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
-  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-  AND display_id IN (
-    SELECT DISTINCT(display_id)
+electronStableDisplays AS (
+  SELECT DISTINCT(display_id)
       FROM `client-side-events.Installer_Events.events*`
       WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
       AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
       AND installer_version NOT LIKE "beta_%"
-      AND event = "install complete"
+),
+
+chromeOSStableDisplays AS (
+  SELECT DISTINCT(id)
+        FROM `client-side-events.ChromeOS_Player_Events.events`
+        WHERE ts BETWEEN TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+        AND TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
+        AND player_version NOT LIKE "beta_%"
+),
+
+allDisplays AS (
+  SELECT DATE(ts) AS date, *
+  FROM `client-side-events.Widget_Events.video_v2_events*`
+  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -3 DAY))
+  AND FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND (
+    display_id IN (SELECT * FROM electronStableDisplays) OR display_id IN (SELECT * FROM chromeOSStableDisplays)
   )
 )
 
@@ -26,7 +37,8 @@ SELECT * FROM (
   FROM (
     SELECT date, COUNT(DISTINCT(display_id)) AS total_count
     FROM allDisplays
-    WHERE (event = "configuration" AND event_details = "storage file (rls)")
+    WHERE event = "configuration"
+    AND event_details = "storage file (rls)"
     GROUP BY date
   ) a
   LEFT JOIN (
@@ -39,7 +51,8 @@ SELECT * FROM (
                 (
                   SELECT CONCAT(display_id, CAST(date AS STRING))
                   FROM allDisplays
-                  WHERE (event = "configuration" AND event_details = "storage file (rls)")
+                  WHERE event = "configuration"
+                  AND event_details = "storage file (rls)"
                 )
 
       UNION ALL
@@ -50,7 +63,8 @@ SELECT * FROM (
       AND CONCAT(display_id, CAST(date AS STRING)) IN (
         SELECT CONCAT(display_id, CAST(date AS STRING))
         FROM allDisplays
-        WHERE (event = "configuration" AND event_details = "storage file (rls)")
+        WHERE event = "configuration"
+        AND event_details = "storage file (rls)"
       )
     )
 


### PR DESCRIPTION
- Measuring reliability of Content against all _non-beta_ Electron and Chrome OS displays
- Converted remaining Content reliability views from legacy to standard SQL