### PR TITLE
Don't allow future days in uptime queries

### DIFF
--- a/projects/client-side-events/datasets/Uptime_Events/views/DisplayUptimePctFourDaysAgoToYesterday.bq
+++ b/projects/client-side-events/datasets/Uptime_Events/views/DisplayUptimePctFourDaysAgoToYesterday.bq
@@ -16,7 +16,7 @@ FROM (
   FROM
     `client-side-events.Uptime_Events.EventsPastFourDays`
   WHERE
-    DATE(ts) != CURRENT_DATE())
+    DATE(ts) < CURRENT_DATE())
 GROUP BY
   date,
   display_id

--- a/projects/client-side-events/datasets/Uptime_Events/views/DisplayUptimePctFourDaysAgoToYesterdayIgnoringNetworkConnectivity.bq
+++ b/projects/client-side-events/datasets/Uptime_Events/views/DisplayUptimePctFourDaysAgoToYesterdayIgnoringNetworkConnectivity.bq
@@ -16,7 +16,7 @@ FROM (
   FROM
     `client-side-events.Uptime_Events.EventsPastFourDays`
   WHERE
-    DATE(ts) != CURRENT_DATE())
+    DATE(ts) < CURRENT_DATE())
 GROUP BY
   date,
   display_id


### PR DESCRIPTION
Noticed some future days showing up in the queries today. 