### PR TITLE
count errors and warnings on all content components

### DIFF
--- a/projects/client-side-events/datasets/Display_Events/component_errors_and_warnings.bq
+++ b/projects/client-side-events/datasets/Display_Events/component_errors_and_warnings.bq
@@ -1,0 +1,21 @@
+#StandardSQL
+
+SELECT level, component, event, count(*) AS count FROM
+(
+  SELECT DISTINCT display_id, source AS component, level, event
+  FROM `client-side-events.Display_Events.events_test`
+  WHERE ts >= "2018-XX-YY 00:00:00"
+  AND ts < "2018-XX-ZZ 00:00:00"
+  AND platform = 'content'
+  AND display_id != 'DISPLAY_ID'
+  AND rollout_stage = 'beta' -- 'stable'
+  AND level IN ( 'severe', 'error', 'warning' )
+)
+GROUP BY level, component, event
+ORDER BY
+  CASE level
+    WHEN 'severe' THEN 1
+    WHEN 'error'  THEN 2
+    ELSE 3
+  END,
+  count DESC


### PR DESCRIPTION
This query will get errors and warning counts for all content components ( not just image component ). I think this is very useful as the output can be very easily exported to a spreadsheet, and further filtered or copied there easily. Much easier than with Current Delivery's error counts.

See example: https://bigquery.cloud.google.com/results/client-side-events:US.bquijob_7cf08c5f_1671de469ca

Relability queries will be a separate PR.
