### PR TITLE
Feature/oauth token provider reliability

### DIFF
--- a/projects/client-side-events/datasets/Component_Events/views/OAuthTokenProviderReliability.bq
+++ b/projects/client-side-events/datasets/Component_Events/views/OAuthTokenProviderReliability.bq
@@ -1,0 +1,5 @@
+#StandardSQL
+
+SELECT date, total_count, failed_count, ((total_count - failed_count)/total_count) as Reliability
+FROM `client-side-events.Aggregate_Tables.OAuthTokenProviderStats`
+ORDER BY date DESC

--- a/projects/client-side-events/datasets/Component_Events/views/OAuthTokenProviderStats.bq
+++ b/projects/client-side-events/datasets/Component_Events/views/OAuthTokenProviderStats.bq
@@ -20,10 +20,8 @@ SELECT * FROM
         AND LOWER( textPayload ) LIKE '%error%'
         AND textPayload LIKE '%companyId: %'
         GROUP BY company_id
-
       )
     ) AS failed_count
-
 
   UNION ALL
 

--- a/projects/client-side-events/datasets/Component_Events/views/OAuthTokenProviderStats.bq
+++ b/projects/client-side-events/datasets/Component_Events/views/OAuthTokenProviderStats.bq
@@ -1,0 +1,34 @@
+#StandardSQL
+
+SELECT * FROM
+(
+  SELECT
+    CURRENT_DATE as date,
+    (
+      SELECT COUNT( DISTINCT company_id )
+      FROM `client-side-events.Component_Events.rise_twitter_events`
+      WHERE _PARTITIONTIME >= TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+      AND _PARTITIONTIME < TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
+    ) as total_count,
+    (
+      SELECT count(*) FROM
+      (
+        SELECT
+          SUBSTR( REGEXP_REPLACE( textPayload, ".*companyId: ([^,]*),", "\\1" ), 1, 36 ) AS company_id
+        FROM `messaging-service-180514.oauth_token_provider_logs.oauth_token_provider_*`
+        WHERE _TABLE_SUFFIX = FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+        AND LOWER( textPayload ) LIKE '%error%'
+        AND textPayload LIKE '%companyId: %'
+        GROUP BY company_id
+
+      )
+    ) AS failed_count
+
+
+  UNION ALL
+
+  SELECT date, total_count, failed_count
+  FROM `client-side-events.Aggregate_Tables.OAuthTokenProviderStats`
+  WHERE date < DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY)
+)
+ORDER BY date DESC


### PR DESCRIPTION
These are the proposed views to track reliability of the OAuth Token Provider. It follows the behavior and naming of similar views. 

But as credentials are generated at company level ( not display level ) this tracks number of companies with failure and total number of companies using the widget ( and not individual display ids ).

An aggregate table is also created to keep track of historical reliability. Scheduling for these queries will be added to client-side-events project in a following PR, and the reliability process and spreadsheet will be updated also to include these.
