### PR TITLE
point to production table

### DIFF
--- a/projects/client-side-events/datasets/Display_Events/ComponentErrorsAndWarnings.bq
+++ b/projects/client-side-events/datasets/Display_Events/ComponentErrorsAndWarnings.bq
@@ -11,7 +11,7 @@ SELECT * FROM
     count(*) AS count FROM
   (
     SELECT DISTINCT display_id, source AS component, rollout_stage, level, event
-    FROM `client-side-events.Display_Events.events_test`
+    FROM `client-side-events.Display_Events.events`
     WHERE ts >= TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
     AND ts < TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
     AND platform = 'content'

--- a/projects/client-side-events/datasets/Display_Events/ComponentStats.bq
+++ b/projects/client-side-events/datasets/Display_Events/ComponentStats.bq
@@ -3,7 +3,7 @@
 WITH component_events AS
 (
   SELECT DISTINCT display_id, rollout_stage, source AS component, level
-  FROM `client-side-events.Display_Events.events_test`
+  FROM `client-side-events.Display_Events.events`
   WHERE ts >= TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
   AND ts < TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
   AND platform = 'content'


### PR DESCRIPTION
The queries should be pointing to the production tables, not the test versions of them.