### PR TITLE
filter out authentication errors

### DIFF
--- a/projects/client-side-events/datasets/Component_Events/views/OAuthTokenProviderReliability.bq
+++ b/projects/client-side-events/datasets/Component_Events/views/OAuthTokenProviderReliability.bq
@@ -31,6 +31,7 @@ FROM
       FROM `messaging-service-180514.oauth_token_provider_logs.oauth_token_provider_*`
       WHERE _TABLE_SUFFIX = FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
       AND LOWER( textPayload ) LIKE '%error%'
+      AND textPayload NOT LIKE '%Could not authenticate%'
       AND textPayload LIKE '%companyId: %'
     )
     GROUP BY date


### PR DESCRIPTION
An authentication error could be related to a user providing wrong credentials, and shouldn't affect content reliability. So I'm filtering out these type of errors.