### PR TITLE
calculate insertion costs on Client Side Applications Table

### DIFF
--- a/projects/client-side-events/datasets/Display_Events/ClientSideApplicationsTableCost.bq
+++ b/projects/client-side-events/datasets/Display_Events/ClientSideApplicationsTableCost.bq
@@ -1,0 +1,18 @@
+#StandardSQL
+
+WITH stats AS
+(
+  SELECT date, platform, source, size_kb, size_kb * cost_per_100mb / ( 1024 * 100 ) AS cost
+  FROM `client-side-events.Aggregate_Tables.ClientSideApplicationsTableStats`
+)
+
+SELECT stats.date, platform, source, stats.size_kb, cost,
+  FORMAT('%.10f', cost) AS cost_string,
+  stats.size_kb / total.size_kb AS participation_percentage
+FROM stats INNER JOIN
+(
+  SELECT date, SUM(size_kb) AS size_kb
+  FROM stats
+  GROUP BY date
+) total
+ON stats.date = total.date

--- a/projects/client-side-events/datasets/Display_Events/ClientSideApplicationsTableStats.bq
+++ b/projects/client-side-events/datasets/Display_Events/ClientSideApplicationsTableStats.bq
@@ -1,0 +1,54 @@
+#StandardSQL
+
+WITH entry_counts AS
+(
+  SELECT platform, source,
+    SUM(
+      DIV(
+        (
+           8 + -- ts
+          11 + -- platform
+          25 + -- source
+          18 + -- version
+           8 + -- rollout_stage
+          14 + -- display id
+          38 + -- company id
+           9 + -- level
+          BYTE_LENGTH(event) +
+          BYTE_LENGTH(IFNULL(event_details, '')) +
+          BYTE_LENGTH(IFNULL(player.ip, '')) +
+          18 + -- player.version
+          BYTE_LENGTH(IFNULL(player.os, '')) +
+          BYTE_LENGTH(IFNULL(player.chrome_version, '')) +
+          BYTE_LENGTH(IFNULL(storage.file_url, '')) +
+          BYTE_LENGTH(IFNULL(storage.file_form, '')) +
+          BYTE_LENGTH(IFNULL(storage.local_url, '')) +
+          BYTE_LENGTH(IFNULL(storage.configuration, '')) +
+          BYTE_LENGTH(IFNULL(storage.file_path, '')) +
+          BYTE_LENGTH(IFNULL(component.id, ''))
+        ), 1024
+      ) + 1
+    ) AS size_kb
+    FROM `client-side-events.Display_Events.events`
+  WHERE ts >= TIMESTAMP( DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY) )
+  AND   ts <  TIMESTAMP( DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY) )
+  GROUP BY platform, source
+)
+
+SELECT * FROM
+(
+  SELECT
+    DATE_ADD( CURRENT_DATE(), INTERVAL -1 DAY ) as date,
+    platform,
+    source,
+    size_kb,
+    0.005 AS cost_per_100mb
+  FROM entry_counts
+
+  UNION ALL
+
+  SELECT date, platform, source, size_kb, cost_per_100mb
+  FROM `client-side-events.Aggregate_Tables.ClientSideApplicationsTableStats`
+  WHERE date < DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY)
+)
+ORDER BY date DESC, platform, source


### PR DESCRIPTION
This is the proposal to track cost for streaming inserts on the Client Side Applications Table.

This calculates cost as defined here:
https://cloud.google.com/bigquery/pricing
Depending on the size of each record as described here:
https://stackoverflow.com/questions/40855461/how-to-calculate-bigquery-row-size

We would schedule the stats query to run daily and populate an aggregate table.
Then the cost query would give us the cost per component, and aggregating those we would get an approximate of the total insertion cost. 
We may decide to track these costs daily or weekly as part of our cost process.

Note also that if Google pricing for streaming inserts ever change, we would need to update our stats query to reflect that change.

This does not calculate pricing for queries on this table, but the relative participation percentage field may help us to see if a component is logging to much, and may help us reduce its amount of logging to what is necessary.

A sample of the cost output for our current test table here:

https://bigquery.cloud.google.com/results/client-side-events:US.bquijob_2a65b561_1676053af14

Note that current cost values are negligible, and that financial component is currently logging more than image component.
