### PR TITLE
query company template usage

### DIFF
--- a/projects/client-side-events/datasets/Widget_Events/queries/TemplateUsageCompaniesPast30Days.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/TemplateUsageCompaniesPast30Days.bq
@@ -8,6 +8,10 @@ FROM
     FROM TABLE_DATE_RANGE([client-side-events:Widget_Events.template_events], DATE_ADD(CURRENT_TIMESTAMP(), -30, 'DAY'), CURRENT_TIMESTAMP())
     WHERE event = 'load'
     AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+    AND template_id NOT IN (
+      '60868bdb-b7cc-44d1-a53e-1cbd5aa70fe9', -- Simple Video Presentation
+      '758113f9-2b45-44a8-9a73-21e09492b92c' -- Simple Image Presentation
+    )
     GROUP BY display_id
   ) AS templates
   INNER JOIN [rise-core-log:coreData.MapDisplayIdCompany] AS core

--- a/projects/client-side-events/datasets/Widget_Events/queries/TemplateUsageCompaniesPast30Days.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/TemplateUsageCompaniesPast30Days.bq
@@ -1,0 +1,23 @@
+SELECT display.count as displayCount, display.companyId, company.name
+FROM
+(
+  SELECT core.company AS companyId, count(*) as count
+  FROM
+  (
+    SELECT display_id
+    FROM TABLE_DATE_RANGE([client-side-events:Widget_Events.template_events], DATE_ADD(CURRENT_TIMESTAMP(), -30, 'DAY'), CURRENT_TIMESTAMP())
+    WHERE event = 'load'
+    AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+    GROUP BY display_id
+  ) AS templates
+  INNER JOIN [rise-core-log:coreData.MapDisplayIdCompany] AS core
+  ON templates.display_id = core.display_id
+  GROUP BY companyId
+) AS display
+INNER JOIN
+(
+  SELECT companyId, name
+  FROM [rise-core-log:coreData.MapCompanyName]
+) AS company
+ON display.companyId = company.companyId
+ORDER BY displayCount DESC

--- a/projects/client-side-events/datasets/Widget_Events/queries/TemplateUsageTotalCompaniesPast30Days.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/TemplateUsageTotalCompaniesPast30Days.bq
@@ -5,6 +5,10 @@ FROM
   FROM TABLE_DATE_RANGE([client-side-events:Widget_Events.template_events], DATE_ADD(CURRENT_TIMESTAMP(), -30, 'DAY'), CURRENT_TIMESTAMP())
   WHERE event = 'load'
   AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND template_id NOT IN (
+    '60868bdb-b7cc-44d1-a53e-1cbd5aa70fe9', -- Simple Video Presentation
+    '758113f9-2b45-44a8-9a73-21e09492b92c' -- Simple Image Presentation
+  )
   GROUP BY display_id
 ) AS templates
 INNER JOIN [rise-core-log:coreData.MapDisplayIdCompany] AS core

--- a/projects/client-side-events/datasets/Widget_Events/queries/TemplateUsageTotalCompaniesPast30Days.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/TemplateUsageTotalCompaniesPast30Days.bq
@@ -1,0 +1,12 @@
+SELECT EXACT_COUNT_DISTINCT(core.company) as numberOfCompanies
+FROM
+(
+  SELECT display_id
+  FROM TABLE_DATE_RANGE([client-side-events:Widget_Events.template_events], DATE_ADD(CURRENT_TIMESTAMP(), -30, 'DAY'), CURRENT_TIMESTAMP())
+  WHERE event = 'load'
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  GROUP BY display_id
+) AS templates
+INNER JOIN [rise-core-log:coreData.MapDisplayIdCompany] AS core
+ON templates.display_id = core.display_id
+ORDER BY numberOfCompanies DESC


### PR DESCRIPTION
TemplateUsageTotalCompaniesPast30Days.bq
  - total count of unique companies that used templates in the past 30 days.

TemplateUsageCompaniesPast30Days.bq:
  - list of companies ( id and name ) that used templates in the past 30 days, ordered by the number of displays owned by each one