### PR TITLE
Fix player module stats query

### DIFF
--- a/projects/client-side-events/datasets/Installer_Events/views/PlayerModuleStats.bq
+++ b/projects/client-side-events/datasets/Installer_Events/views/PlayerModuleStats.bq
@@ -35,7 +35,8 @@ SELECT * FROM (
       UNION ALL
 
       SELECT date, display_id FROM allDisplays
-      WHERE event = 'launching viewer'
+      WHERE event = 'loading url'
+      AND event_details like 'https://viewer.risevision.com/Viewer.html%'
       AND CONCAT(display_id, CAST(date AS STRING)) NOT IN
       (
         SELECT CONCAT(display_id, CAST(DATE(ts) AS STRING))


### PR DESCRIPTION
Only account for 'startup' events on Viewer_Events.events table when the actual viewer URL is loaded.

This query got outdated when we released no viewer mode.