### PR TITLE
Refactor uptime for company snapshot compatability

### DIFF
--- a/projects/Rise_Stats/datasets/customerData/views/companySnapshot.bq
+++ b/projects/Rise_Stats/datasets/customerData/views/companySnapshot.bq
@@ -241,7 +241,7 @@ select
   D.companyId,
   avg(U.day_uptime_pct) as uptime
 from productionDisplays D
-inner join (select day_uptime_pct, display_id from `client-side-events.Uptime_Events.DisplayUptimePctFourDaysAgoToYesterday` where date = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)) U on D.displayId = U.display_id
+inner join (select day_uptime_pct, display_id from `client-side-events.Uptime_Events.DailyUptimePerDisplay` where date = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)) U on D.displayId = U.display_id
 group by 1
 ), 
 

--- a/projects/client-side-events/datasets/Uptime_Events/views/AverageUptimePct.bq
+++ b/projects/client-side-events/datasets/Uptime_Events/views/AverageUptimePct.bq
@@ -1,14 +1,3 @@
 #standardSQL
-with displayUptimes as (
-select date, greatest(0, rendererRunningAndMSConnected - fiveMinuteIntervalsWithWhitescreen) / scheduledFiveMinIntervals * 100 uptime_pct
-  from (
-    SELECT
-    date,
-    display_id,
-    rendererRunningAndMSConnected,
-    scheduledFiveMinIntervals,
-    ifnull(fiveMinuteIntervalsWithWhitescreen, 0) fiveMinuteIntervalsWithWhitescreen
-    FROM
-    `client-side-events.Uptime_Events.UptimeWithWhitescreen`))
-
-select date, avg(uptime_pct) average_uptime_pct from displayUptimes group by date order by date desc
+select date, avg(day_uptime_pct) average_uptime_pct from `client-side-events.Uptime_Events.DailyUptimePerDisplay`
+group by date order by date desc

--- a/projects/client-side-events/datasets/Uptime_Events/views/DailyUptimePerDisplay.bq
+++ b/projects/client-side-events/datasets/Uptime_Events/views/DailyUptimePerDisplay.bq
@@ -1,0 +1,10 @@
+select date, greatest(0, rendererRunningAndMSConnected - fiveMinuteIntervalsWithWhitescreen) / scheduledFiveMinIntervals * 100 day_uptime_pct, display_id
+  from (
+    SELECT
+    date,
+    display_id,
+    rendererRunningAndMSConnected,
+    scheduledFiveMinIntervals,
+    ifnull(fiveMinuteIntervalsWithWhitescreen, 0) fiveMinuteIntervalsWithWhitescreen
+    FROM
+    `client-side-events.Uptime_Events.UptimeWithWhitescreen`)


### PR DESCRIPTION
companySnapshot was using the previously deleted obsolete view that didn't take whitescreen into account.