### PR TITLE
Exclude sub companies from newSignups calculation

### DIFF
--- a/projects/Rise_Stats/datasets/customerData/views/brandPromiseKPIs.bq
+++ b/projects/Rise_Stats/datasets/customerData/views/brandPromiseKPIs.bq
@@ -14,7 +14,8 @@ select
   count(distinct C.companyId) as newSignups
 from `rise-core-log.coreData.companies` C
 inner join (select max(id) as id, companyId from `rise-core-log.coreData.companies` group by companyId) CC on C.id=CC.id
-where C.appId = 's~rvaserver2' and C.isTest = false and C.creationDate >= timestamp(DATE_SUB(current_date(), INTERVAL 7 DAY)) and DATE(C.creationDate) < CURRENT_DATE()
+where C.appId = 's~rvaserver2' and C.isTest = false and C.parentId = 'f114ad26-949d-44b4-87e9-8528afc76ce4'
+and C.creationDate >= timestamp(DATE_SUB(current_date(), INTERVAL 7 DAY)) and DATE(C.creationDate) < CURRENT_DATE()
 ),
 
 contentUpdates as 


### PR DESCRIPTION
Brand promise should not count companies added as sub companies.

@sheadarlison @alanclayton FYI