### PR TITLE
Remove white screen check errors from ChrOS player reliabilitty

### DIFF
--- a/projects/client-side-events/datasets/ChromeOS_Player_Events/views/reliability.bq
+++ b/projects/client-side-events/datasets/ChromeOS_Player_Events/views/reliability.bq
@@ -28,6 +28,7 @@ errorsCurrentVersion AS (
     UPPER(event) LIKE "%ERROR%"
     and event != 'network check error'
     and event != 'showing network error'
+    and event != 'white screen external URL check error'
     and (event != 'marketwall - send display id error' and event_details not like '%net::ERR_SOCKET_NOT_CONNECTED%'))
     
 SELECT


### PR DESCRIPTION
- Theese errors were added to help investigate white screen events due to external content
