### PR TITLE
Feature/query displays using templates

### DIFF
--- a/projects/client-side-events/datasets/Display_Events/DisplaysUsingHtmlTemplates.js
+++ b/projects/client-side-events/datasets/Display_Events/DisplaysUsingHtmlTemplates.js
@@ -23,7 +23,7 @@ SELECT * FROM
   UNION ALL
 
   SELECT date, template, display_id, company_id
-  FROM `client-side-events.Aggregate_Tables.DisplaysUsingTemplates`
+  FROM `client-side-events.Aggregate_Tables.DisplaysUsingHtmlTemplates`
   WHERE date < DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY)
 )
 ORDER BY date DESC, template

--- a/projects/client-side-events/datasets/Display_Events/DisplaysUsingHtmlTemplates.js
+++ b/projects/client-side-events/datasets/Display_Events/DisplaysUsingHtmlTemplates.js
@@ -14,7 +14,6 @@ SELECT * FROM
     WHERE ts >= TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
     AND ts < TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
     AND platform = 'content'
-    AND display_id != 'DISPLAY_ID'
     AND rollout_stage IN( 'beta', 'stable' )
     AND template.product_code IS NOT NULL
     GROUP BY 1, 2, 3

--- a/projects/client-side-events/datasets/Display_Events/DisplaysUsingTemplates.js
+++ b/projects/client-side-events/datasets/Display_Events/DisplaysUsingTemplates.js
@@ -1,0 +1,29 @@
+#StandardSQL
+
+SELECT * FROM
+(
+  SELECT
+    DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY) as date,
+    template,
+    display_id,
+    company_id
+  FROM
+  (
+    SELECT display_id, company_id, template.product_code AS template
+    FROM `client-side-events.Display_Events.events`
+    WHERE ts >= TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+    AND ts < TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
+    AND platform = 'content'
+    AND display_id != 'DISPLAY_ID'
+    AND rollout_stage IN( 'beta', 'stable' )
+    AND template.product_code IS NOT NULL
+    GROUP BY 1, 2, 3
+  ) AS total
+
+  UNION ALL
+
+  SELECT date, template, display_id, company_id
+  FROM `client-side-events.Aggregate_Tables.DisplaysUsingTemplates`
+  WHERE date < DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY)
+)
+ORDER BY date DESC, template


### PR DESCRIPTION
This obtains the displays using a particular template, and will help to easily build the queries of displays per day, per week and per month against an aggregate table.

JTBD: As Rise, I know how many displays a template played on that day, week, month.

Currently it returns just one row:
https://bigquery.cloud.google.com/results/client-side-events:US.bquijob_48e03d3e_169a13a28f3
