### PR TITLE
Feature/add displays using html templates by day week month

### DIFF
--- a/projects/client-side-events/datasets/Display_Events/DisplaysUsingHtmlTemplatesByDay.js
+++ b/projects/client-side-events/datasets/Display_Events/DisplaysUsingHtmlTemplatesByDay.js
@@ -1,0 +1,7 @@
+#StandardSQL
+
+SELECT date, template, COUNT( DISTINCT display_id ) as number_of_displays
+FROM `client-side-events.Aggregate_Tables.DisplaysUsingHtmlTemplates`
+WHERE date > DATE_ADD(CURRENT_DATE(), INTERVAL -30 DAY)
+GROUP BY date, template
+ORDER BY date DESC, template

--- a/projects/client-side-events/datasets/Display_Events/DisplaysUsingHtmlTemplatesByMonth.js
+++ b/projects/client-side-events/datasets/Display_Events/DisplaysUsingHtmlTemplatesByMonth.js
@@ -1,0 +1,7 @@
+#StandardSQL
+
+SELECT template, COUNT( DISTINCT display_id ) as number_of_displays
+FROM `client-side-events.Aggregate_Tables.DisplaysUsingHtmlTemplates`
+WHERE date > DATE_ADD(CURRENT_DATE(), INTERVAL -30 DAY)
+GROUP BY template
+ORDER BY template

--- a/projects/client-side-events/datasets/Display_Events/DisplaysUsingHtmlTemplatesByWeek.js
+++ b/projects/client-side-events/datasets/Display_Events/DisplaysUsingHtmlTemplatesByWeek.js
@@ -1,0 +1,7 @@
+#StandardSQL
+
+SELECT template, COUNT( DISTINCT display_id ) as number_of_displays
+FROM `client-side-events.Aggregate_Tables.DisplaysUsingHtmlTemplates`
+WHERE date > DATE_ADD(CURRENT_DATE(), INTERVAL -7 DAY)
+GROUP BY template
+ORDER BY template


### PR DESCRIPTION
The day query makes the grouping by date, and returns the counts for the last 30 days per template ( it could be restricted to 1 day instead ).

The week query groups the last 7 days, and returns a single row per template.

The month query groups the last 30 days, and returns a single row per template.

We currently have no data in the aggregate table to test them, the data will be coming once scheduling begins.

The current queries report using product code, but that will change to template name as soon as we have it. No changes to these queries are needed for that.

@sheadarlison are all of the above descriptions ok ?
