### PR TITLE
Add query for Companies using a given Template per day

### DIFF
--- a/projects/client-side-events/datasets/Display_Events/CompaniesUsingHtmlTemplatesByDay.js
+++ b/projects/client-side-events/datasets/Display_Events/CompaniesUsingHtmlTemplatesByDay.js
@@ -1,0 +1,7 @@
+#StandardSQL
+
+SELECT date, template, COUNT( DISTINCT company_id ) as number_of_companies
+FROM `client-side-events.Aggregate_Tables.DisplaysUsingHtmlTemplates`
+WHERE date > DATE_ADD(CURRENT_DATE(), INTERVAL -30 DAY)
+GROUP BY date, template
+ORDER BY date DESC, template


### PR DESCRIPTION
Currently we don't have data to validate this. I was also wondering if we should have a query that returns average usage per day for each template, but I guess that would be a separate card (if at all needed).

@santiagonoguez @stulees please review
