### PR TITLE
filter out empty template names

### DIFF
--- a/projects/client-side-events/datasets/Display_Events/DisplaysUsingHtmlTemplates.js
+++ b/projects/client-side-events/datasets/Display_Events/DisplaysUsingHtmlTemplates.js
@@ -16,6 +16,7 @@ SELECT * FROM
     AND platform = 'content'
     AND rollout_stage IN( 'beta', 'stable' )
     AND template.name IS NOT NULL
+    AND template.name != ''
     GROUP BY 1, 2, 3
   ) AS total
 


### PR DESCRIPTION
A simple additional filter to avoid empty names in the reports