### PR TITLE
Feature/update k12 queries

### DIFF
--- a/projects/client-side-events/datasets/Display_Events/ActiveDisplays.bq
+++ b/projects/client-side-events/datasets/Display_Events/ActiveDisplays.bq
@@ -1,0 +1,25 @@
+#StandardSQL
+
+WITH electronActiveDisplays AS
+(
+  SELECT display_id AS displayId
+  FROM `client-side-events.Installer_Events.events*`
+  WHERE _TABLE_SUFFIX BETWEEN
+    FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -4 DAY))
+  AND
+    FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+),
+
+chromeOsActiveDisplays AS
+(
+  SELECT id AS displayId
+  FROM `client-side-events.ChromeOS_Player_Events.events`
+  WHERE ts BETWEEN
+    TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -4 DAY))
+  AND
+    TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
+)
+
+SELECT displayID FROM electronActiveDisplays
+UNION ALL
+SELECT displayID FROM chromeOsActiveDisplays

--- a/projects/client-side-events/datasets/Widget_Events/queries/K12Companies.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/K12Companies.bq
@@ -1,0 +1,12 @@
+#StandardSQL
+
+SELECT c.companyId
+FROM `rise-core-log.coreData.companies` c
+INNER JOIN
+(
+  SELECT MAX(id) AS id, companyId
+  FROM `rise-core-log.coreData.companies`
+  GROUP BY companyId
+) cc ON c.id = cc.id
+WHERE c.appId = 's~rvaserver2' and c.isTest = false
+AND c.companyIndustry = 'PRIMARY_SECONDARY_EDUCATION'

--- a/projects/client-side-events/datasets/Widget_Events/queries/K12CompaniesUsingTemplatesStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/K12CompaniesUsingTemplatesStats.bq
@@ -62,7 +62,7 @@ SELECT * FROM
       UNION ALL
       SELECT * FROM k12ActiveCompaniesUsingHtmlTemplates
     )
-    GROUP BY 2
+    GROUP BY date
   )
 
   UNION ALL

--- a/projects/client-side-events/datasets/Widget_Events/queries/K12CompaniesUsingTemplatesStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/K12CompaniesUsingTemplatesStats.bq
@@ -1,21 +1,46 @@
 #StandardSQL
 
-WITH k12Companies AS
+WITH k12ActiveCompanies AS
 (
-  SELECT c.companyId
-  FROM `rise-core-log.coreData.companies` c
-  INNER JOIN
+  SELECT companyId
+  FROM `client-side-events.Widget_Events.K12Companies`
+  WHERE companyId IN
   (
-    SELECT MAX(id) AS id, companyId
-    FROM `rise-core-log.coreData.companies`
-    GROUP BY companyId
-  ) cc ON c.id = cc.id
-  WHERE c.appId = 's~rvaserver2' and c.isTest = false
-  AND c.companyIndustry IN (
-    'HIGHER_EDUCATION',
-    'PRIMARY_SECONDARY_EDUCATION',
-    'EDUCATION_MANAGEMENT'
+    SELECT companyId FROM `rise-core-log.coreData.displays`
+    WHERE displayId IN(
+      SELECT displayID
+      FROM `client-side-events.Display_Events.ActiveDisplays`
+    )
   )
+),
+
+k12ActiveCompaniesUsingLegacyTemplates AS
+(
+  SELECT core.companyId, templates.date
+  FROM
+  (
+    SELECT display_id, DATE(ts) AS date
+    FROM `client-side-events.Widget_Events.template_events*`
+    WHERE _TABLE_SUFFIX = FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+    AND event = 'load'
+    AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+    AND template_id NOT IN (
+      '60868bdb-b7cc-44d1-a53e-1cbd5aa70fe9', -- Simple Video Presentation
+      '758113f9-2b45-44a8-9a73-21e09492b92c' -- Simple Image Presentation
+    )
+    GROUP BY display_id, date
+  ) AS templates
+  INNER JOIN `rise-core-log.coreData.displays` AS core
+  ON templates.display_id = core.displayId
+  WHERE core.companyId IN ( SELECT companyId FROM k12ActiveCompanies )
+),
+
+k12ActiveCompaniesUsingHtmlTemplates AS
+(
+  SELECT company_id, date
+  FROM `client-side-events.Aggregate_Tables.DisplaysUsingHtmlTemplates`
+  WHERE date = DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY)
+  AND company_id IN ( SELECT companyId FROM k12ActiveCompanies )
 )
 
 SELECT * FROM
@@ -23,51 +48,24 @@ SELECT * FROM
   SELECT
     date,
     (
-      SELECT COUNT(DISTINCT companyId) FROM k12Companies
+      SELECT COUNT(DISTINCT companyId) FROM k12ActiveCompanies
     ) AS numberOfK12Companies,
     numberOfK12CompaniesUsingTemplates
   FROM
   (
     SELECT
-      COUNT(DISTINCT core.companyId) as numberOfK12CompaniesUsingTemplates,
-      templates.date
+      COUNT(DISTINCT companyId) as numberOfK12CompaniesUsingTemplates,
+      date
     FROM
     (
-      SELECT display_id, date
-      FROM
-      (
-        SELECT display_id, DATE(ts) AS date
-        FROM `client-side-events.Widget_Events.template_events*`
-        WHERE _TABLE_SUFFIX = FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
-        AND event = 'load'
-        AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-        AND template_id NOT IN (
-          '60868bdb-b7cc-44d1-a53e-1cbd5aa70fe9', -- Simple Video Presentation
-          '758113f9-2b45-44a8-9a73-21e09492b92c' -- Simple Image Presentation
-        )
-
-        UNION ALL
-
-        SELECT display_id, DATE(ts) AS date
-        FROM `client-side-events.Display_Events.events*`
-        WHERE ts >= TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
-        AND ts < TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
-        AND platform = 'content'
-        AND rollout_stage IN( 'beta', 'stable' )
-        AND template.name IS NOT NULL
-        AND template.name != ""
-        AND event = "rise-components-ready"
-      )
-      GROUP BY display_id, date
-    ) AS templates
-    INNER JOIN `rise-core-log.coreData.displays` AS core
-    ON templates.display_id = core.displayId
-    WHERE core.companyId IN ( SELECT companyId FROM k12Companies )
+      SELECT * FROM k12ActiveCompaniesUsingLegacyTemplates
+      UNION ALL
+      SELECT * FROM k12ActiveCompaniesUsingHtmlTemplates
+    )
     GROUP BY 2
   )
 
   UNION ALL
-
 
   SELECT date, numberOfK12Companies, numberOfK12CompaniesUsingTemplates
   FROM `client-side-events.Aggregate_Tables.K12CompaniesUsingTemplatesStats`

--- a/projects/client-side-events/datasets/Widget_Events/queries/K12DisplaysUsingTemplatesStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/K12DisplaysUsingTemplatesStats.bq
@@ -28,7 +28,7 @@ k12ActiveDisplaysUsingLegacyTemplates AS
   WHERE _TABLE_SUFFIX = FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
   AND event = 'load'
   AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-  AND display_id IN ( SELECT displayId FROM k12Displays )
+  AND display_id IN ( SELECT displayId FROM k12ActiveDisplays )
   AND template_id NOT IN (
     '60868bdb-b7cc-44d1-a53e-1cbd5aa70fe9', -- Simple Video Presentation
     '758113f9-2b45-44a8-9a73-21e09492b92c' -- Simple Image Presentation
@@ -40,7 +40,7 @@ k12ActiveDisplaysUsingHtmlTemplates AS
   SELECT display_id, date
   FROM `client-side-events.Aggregate_Tables.DisplaysUsingHtmlTemplates`
   WHERE date = DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY)
-  AND display_id IN ( SELECT displayId FROM k12Displays )
+  AND display_id IN ( SELECT displayId FROM k12ActiveDisplays )
 )
 
 SELECT * FROM

--- a/projects/client-side-events/datasets/Widget_Events/queries/K12DisplaysUsingTemplatesStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/K12DisplaysUsingTemplatesStats.bq
@@ -60,7 +60,7 @@ SELECT * FROM
       UNION ALL
       SELECT * FROM k12ActiveDisplaysUsingHtmlTemplates
     )
-    GROUP BY 2
+    GROUP BY date
   )
 
   UNION ALL

--- a/projects/client-side-events/datasets/Widget_Events/queries/K12DisplaysUsingTemplatesStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/K12DisplaysUsingTemplatesStats.bq
@@ -1,60 +1,46 @@
 #StandardSQL
 
-WITH k12Companies AS
-(
-  SELECT c.companyId
-  FROM `rise-core-log.coreData.companies` c
-  INNER JOIN
-  (
-    SELECT MAX(id) AS id, companyId
-    FROM `rise-core-log.coreData.companies`
-    GROUP BY companyId
-  ) cc ON c.id = cc.id
-  WHERE c.appId = 's~rvaserver2' and c.isTest = false
-  AND c.companyIndustry IN (
-    'HIGHER_EDUCATION',
-    'PRIMARY_SECONDARY_EDUCATION',
-    'EDUCATION_MANAGEMENT'
-  )
-),
-
-k12Displays AS
+WITH k12Displays AS
 (
   SELECT displayId
   FROM `rise-core-log.coreData.displays`
-  WHERE companyId IN ( SELECT companyId FROM k12Companies )
-),
-
-electronActiveDisplays AS
-(
-  SELECT display_id AS displayId
-  FROM `client-side-events.Installer_Events.events*`
-  WHERE _TABLE_SUFFIX BETWEEN
-    FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -8 DAY))
-  AND
-    FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
-),
-
-chromeOsActiveDisplays AS
-(
-  SELECT id AS displayId
-  FROM `client-side-events.ChromeOS_Player_Events.events`
-  WHERE ts BETWEEN
-    TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -8 DAY))
-  AND
-    TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
+  WHERE companyId IN
+  (
+    SELECT companyId
+    FROM `client-side-events.Widget_Events.K12Companies`
+  )
 ),
 
 k12ActiveDisplays AS
 (
-  SELECT displayId
-  FROM k12Displays
+  SELECT displayId FROM k12Displays
   WHERE displayId IN
   (
-    SELECT displayID FROM electronActiveDisplays
-    UNION ALL
-    SELECT displayID FROM chromeOsActiveDisplays
+    SELECT displayID
+    FROM `client-side-events.Display_Events.ActiveDisplays`
   )
+),
+
+k12ActiveDisplaysUsingLegacyTemplates AS
+(
+  SELECT display_id, DATE(ts) AS date
+  FROM `client-side-events.Widget_Events.template_events*`
+  WHERE _TABLE_SUFFIX = FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+  AND event = 'load'
+  AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+  AND display_id IN ( SELECT displayId FROM k12Displays )
+  AND template_id NOT IN (
+    '60868bdb-b7cc-44d1-a53e-1cbd5aa70fe9', -- Simple Video Presentation
+    '758113f9-2b45-44a8-9a73-21e09492b92c' -- Simple Image Presentation
+  )
+),
+
+k12ActiveDisplaysUsingHtmlTemplates AS
+(
+  SELECT display_id, date
+  FROM `client-side-events.Aggregate_Tables.DisplaysUsingHtmlTemplates`
+  WHERE date = DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY)
+  AND display_id IN ( SELECT displayId FROM k12Displays )
 )
 
 SELECT * FROM
@@ -65,35 +51,16 @@ SELECT * FROM
     numberOfK12DisplaysUsingTemplates
   FROM
   (
-    SELECT COUNT(DISTINCT(display_id)) as numberOfK12DisplaysUsingTemplates, date
-    FROM (
-      SELECT display_id, DATE(ts) AS date
-        FROM `client-side-events.Widget_Events.template_events*`
-        WHERE _TABLE_SUFFIX = FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
-        AND event = 'load'
-        AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
-        AND display_id IN ( SELECT displayId FROM k12Displays )
-        AND template_id NOT IN (
-          '60868bdb-b7cc-44d1-a53e-1cbd5aa70fe9', -- Simple Video Presentation
-          '758113f9-2b45-44a8-9a73-21e09492b92c' -- Simple Image Presentation
-        )
-        GROUP BY display_id, date
-
+    SELECT
+      COUNT(DISTINCT display_id) as numberOfK12DisplaysUsingTemplates,
+      date
+    FROM
+    (
+      SELECT * FROM k12ActiveDisplaysUsingLegacyTemplates
       UNION ALL
-
-      SELECT display_id, DATE(ts) AS date
-        FROM `client-side-events.Display_Events.events*`
-        WHERE ts >= TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
-        AND ts < TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
-        AND platform = 'content'
-        AND rollout_stage IN( 'beta', 'stable' )
-        AND display_id IN ( SELECT displayId FROM k12Displays )
-        AND template.name IS NOT NULL
-        AND template.name != ""
-        AND event = "rise-components-ready"
-        GROUP BY display_id, date
+      SELECT * FROM k12ActiveDisplaysUsingHtmlTemplates
     )
-    GROUP BY date
+    GROUP BY 2
   )
 
   UNION ALL


### PR DESCRIPTION
This updates the first two queries requested in the card. https://trello.com/c/PGAbqY8m/6868-k-12-template-usage-queries-2

For display query:
- targets only primary secondary education
- active companies was adjusted from 7 days to 3

For company query:
- targets only primary secondary education
- now only considers active companies ( activity during last 3 days )

The K12 companies and active displays queries were shared by both queries, so they were extracted as independent files reused by the other queries.

Both queries for HTML templates now leverage an aggregate table ( DisplaysUsingHtmlTemplates ) to make the query more efficient.

Can be tested directly ( the following links may expire, but the queries can be performed again from source code ).
- Displays: https://bigquery.cloud.google.com/results/client-side-events:US.bquijob_389b1e96_16b09df10be
- Companies: https://bigquery.cloud.google.com/results/client-side-events:US.bquijob_2446779b_16b09d86f6d

@sheadarlison 

Please remember apply the changes on Big Query UI