### PR TITLE
Feature/k12 companies using recommended templates

### DIFF
--- a/projects/client-side-events/datasets/Display_Events/K12CompaniesUsingRecommendedTemplates.bq
+++ b/projects/client-side-events/datasets/Display_Events/K12CompaniesUsingRecommendedTemplates.bq
@@ -1,0 +1,66 @@
+#StandardSQL
+
+WITH recommendedTemplates AS
+(
+  SELECT template
+  FROM `client-side-events.Display_Events.RecommendedTemplates`
+  WHERE DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY)
+    BETWEEN start_date AND end_date
+),
+
+k12ActiveCompaniesUsingRecommendedLegacyTemplates AS
+(
+  SELECT core.companyId AS company_id, templates.date
+  FROM
+  (
+    SELECT display_id, DATE(ts) AS date
+    FROM `client-side-events.Widget_Events.template_events*`
+    WHERE _TABLE_SUFFIX = FORMAT_DATE('%E4Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+    AND event = 'load'
+    AND display_id NOT IN ('preview', '"display_id"', '"displayId"')
+    AND template_id IN ( SELECT template FROM recommendedTemplates )
+    GROUP BY display_id, date
+  ) AS templates
+  INNER JOIN `rise-core-log.coreData.displays` AS core
+  ON templates.display_id = core.displayId
+  WHERE core.companyId IN
+  (
+    SELECT companyId
+    FROM `client-side-events.Widget_Events.K12Companies`
+  )
+),
+
+k12ActiveCompaniesUsingRecommendedHtmlTemplates AS
+(
+  SELECT company_id, DATE(ts)
+  FROM `client-side-events.Display_Events.events`
+  WHERE ts >= TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+  AND ts < TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
+  AND platform = 'content'
+  AND rollout_stage IN( 'beta', 'stable' )
+  AND template.product_code IN ( SELECT template FROM recommendedTemplates )
+  AND company_id IN
+  (
+    SELECT companyId
+    FROM `client-side-events.Widget_Events.K12Companies`
+  )
+)
+
+SELECT * FROM
+(
+  SELECT date, COUNT(DISTINCT company_id) AS number_of_companies FROM
+  (
+    SELECT * FROM k12ActiveCompaniesUsingRecommendedLegacyTemplates
+    UNION ALL
+    SELECT * FROM k12ActiveCompaniesUsingRecommendedHtmlTemplates
+  )
+  WHERE date = DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY)
+  GROUP BY date
+
+  UNION ALL
+
+  SELECT date, number_of_companies
+  FROM `client-side-events.Aggregate_Tables.K12CompaniesUsingRecommendedTemplates`
+  WHERE date < DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY)
+)
+ORDER BY date DESC

--- a/projects/client-side-events/datasets/Widget_Events/queries/K12CompaniesUsingTemplatesStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/K12CompaniesUsingTemplatesStats.bq
@@ -62,6 +62,7 @@ SELECT * FROM
       UNION ALL
       SELECT * FROM k12ActiveCompaniesUsingHtmlTemplates
     )
+    WHERE date = DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY)
     GROUP BY date
   )
 

--- a/projects/client-side-events/datasets/Widget_Events/queries/K12DisplaysUsingTemplatesStats.bq
+++ b/projects/client-side-events/datasets/Widget_Events/queries/K12DisplaysUsingTemplatesStats.bq
@@ -60,6 +60,7 @@ SELECT * FROM
       UNION ALL
       SELECT * FROM k12ActiveDisplaysUsingHtmlTemplates
     )
+    WHERE date = DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY)
     GROUP BY date
   )
 


### PR DESCRIPTION
This is the query that gets number of K12 companies that used recommended templates the day before, and feed and aggregate table as we usually do.

The recommended templates have to be manually configured in this spreadsheet ( start date, end date and template product code ):
https://docs.google.com/spreadsheets/d/18Xx3rOgaeJpunCYF-oSkoRLVc6ew0ib71ChwU6RlBYo/edit#gid=0

That spreadsheet is used as source of the following BQ table:
https://bigquery.cloud.google.com/table/client-side-events:Display_Events.RecommendedTemplates

----

Also, I added an extra filter to the K12 template queries, when I was generating the 90 day historical data for this query on Friday, I noticed that occasionally an extra noise row ( that we've been seeing sometimes appear on aggregate tables ) was produced unless this extra filter was added. 


Please remember apply the changes on Big Query UI
