### PR TITLE
Helpful component/Template editor release queries

### DIFF
--- a/projects/client-side-events/datasets/Display_Events/ComponentPresentationUsage.bq
+++ b/projects/client-side-events/datasets/Display_Events/ComponentPresentationUsage.bq
@@ -18,20 +18,17 @@ SELECT DISTINCT display_id, template.presentation_id as presentation_id, company
   AND source = 'rise-XXXX' -- component name, i.e. rise-image
 )
 
-SELECT * FROM
-(
-  SELECT
-    DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY) as date,
-    total.company_id,
-    total.component,
-    total.template_name,
-    total.presentation_id,
-    total.count AS display_count
-  FROM
-    (
-      SELECT presentation_id, component, company_id, template_name, count(*) AS count FROM
-        ( SELECT * FROM presentations )
-      GROUP BY 1,2,3,4
-    ) AS total
-)
-ORDER BY date DESC, company_id, display_count DESC
+SELECT
+  DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY) as date,
+  total.company_id,
+  total.component,
+  total.template_name,
+  total.presentation_id,
+  total.count AS display_count
+FROM
+  (
+    SELECT presentation_id, component, company_id, template_name, count(*) AS count FROM
+      ( SELECT * FROM presentations )
+    GROUP BY 1,2,3,4
+  ) AS total
+ORDER BY company_id, display_count DESC

--- a/projects/client-side-events/datasets/Display_Events/ComponentPresentationUsage.bq
+++ b/projects/client-side-events/datasets/Display_Events/ComponentPresentationUsage.bq
@@ -1,0 +1,37 @@
+#StandardSQL
+
+WITH presentations AS
+(
+SELECT DISTINCT display_id, template.presentation_id as presentation_id, company_id, template.name as template_name, source AS component, version
+  FROM `client-side-events.Display_Events.events`
+  WHERE ts >= TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+  AND ts < TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
+  AND platform = 'content'
+  AND display_id != 'DISPLAY_ID'
+  AND company_id NOT IN -- test companies
+  (
+    '7fa5ee92-7deb-450b-a8d5-e5ed648c575f',
+    'fee1f642-cdd1-4bc4-8f93-1fc97cb00d55',
+    'a9575a1e-00a8-4d87-b640-979d0623f844'
+  )
+  AND rollout_stage = 'stable'
+  AND source = 'rise-XXXX' -- component name, i.e. rise-image
+)
+
+SELECT * FROM
+(
+  SELECT
+    DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY) as date,
+    total.company_id,
+    total.component,
+    total.template_name,
+    total.presentation_id,
+    total.count AS display_count
+  FROM
+    (
+      SELECT presentation_id, component, company_id, template_name, count(*) AS count FROM
+        ( SELECT * FROM presentations )
+      GROUP BY 1,2,3,4
+    ) AS total
+)
+ORDER BY date DESC, company_id, display_count DESC

--- a/projects/client-side-events/datasets/Display_Events/ComponentVersionStats.bq
+++ b/projects/client-side-events/datasets/Display_Events/ComponentVersionStats.bq
@@ -1,0 +1,36 @@
+#StandardSQL
+
+WITH component_events AS
+(
+  SELECT DISTINCT display_id, rollout_stage, source AS component, version
+  FROM `client-side-events.Display_Events.events`
+  WHERE ts >= TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY))
+  AND ts < TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -0 DAY))
+  AND platform = 'content'
+  AND display_id != 'DISPLAY_ID'
+  AND company_id NOT IN -- test companies
+  (
+    '7fa5ee92-7deb-450b-a8d5-e5ed648c575f',
+    'fee1f642-cdd1-4bc4-8f93-1fc97cb00d55',
+    'a9575a1e-00a8-4d87-b640-979d0623f844'
+  )
+  AND rollout_stage IN( 'beta', 'stable' )
+  AND source = 'rise-XXXX' -- component name, i.e. rise-image
+)
+
+SELECT * FROM
+(
+  SELECT
+    DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY) as date,
+    total.rollout_stage,
+    total.component,
+    total.version,
+    total.count AS display_count
+  FROM
+    (
+      SELECT rollout_stage, component, version, count(*) AS count FROM
+        ( SELECT * FROM component_events )
+      GROUP BY rollout_stage, component, version
+    ) AS total
+)
+ORDER BY date DESC, rollout_stage DESC, display_count DESC

--- a/projects/client-side-events/datasets/Display_Events/ComponentVersionStats.bq
+++ b/projects/client-side-events/datasets/Display_Events/ComponentVersionStats.bq
@@ -18,19 +18,16 @@ WITH component_events AS
   AND source = 'rise-XXXX' -- component name, i.e. rise-image
 )
 
-SELECT * FROM
-(
-  SELECT
-    DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY) as date,
-    total.rollout_stage,
-    total.component,
-    total.version,
-    total.count AS display_count
-  FROM
-    (
-      SELECT rollout_stage, component, version, count(*) AS count FROM
-        ( SELECT * FROM component_events )
-      GROUP BY rollout_stage, component, version
-    ) AS total
-)
-ORDER BY date DESC, rollout_stage DESC, display_count DESC
+SELECT
+  DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY) as date,
+  total.rollout_stage,
+  total.component,
+  total.version,
+  total.count AS display_count
+FROM
+  (
+    SELECT rollout_stage, component, version, count(*) AS count FROM
+      ( SELECT * FROM component_events )
+    GROUP BY rollout_stage, component, version
+  ) AS total
+ORDER BY rollout_stage DESC, display_count DESC


### PR DESCRIPTION
- In order to release the overall fix for issue https://github.com/Rise-Vision/rise-vision-apps/issues/1063 , the _rise-image_ component must be released first and all displays must be using it before releasing Template Editor changes. To monitor how many displays are using latest release of a component, I've added _ComponentVersionStats.bq_.
- As a part of a Rollback plan also for issue 1063, it will be necessary to get a list of presentation ids (along with their respective company ids) that use the image component. This list will be used in collaboration with a list of companies that used Template Editor from FullStory. I've added _ComponentPresentationUsage.bq_ to get this presentation id list for a component. 

FYI, not adding the PR Template for this repo as it doesn't seem necessary. 