### PR TITLE
Adding unified stable component reliability view

### DIFF
--- a/projects/client-side-events/datasets/Display_Events/ComponentReliabilityStable.bq
+++ b/projects/client-side-events/datasets/Display_Events/ComponentReliabilityStable.bq
@@ -1,0 +1,69 @@
+#standardSQL
+
+WITH financial AS
+(
+  SELECT date, Reliability FROM `client-side-events.Display_Events.ComponentReliability` WHERE rollout_stage='stable' AND component='rise-data-financial' limit 7
+),
+rss AS
+(
+  SELECT date, Reliability FROM `client-side-events.Display_Events.ComponentReliability` WHERE rollout_stage='stable' AND component='rise-data-rss' limit 7
+),
+weather AS
+(
+  SELECT date, Reliability FROM `client-side-events.Display_Events.ComponentReliability` WHERE rollout_stage='stable' AND component='rise-data-weather' limit 7
+),
+image AS
+(
+  SELECT date, Reliability FROM `client-side-events.Display_Events.ComponentReliability` WHERE rollout_stage='stable' AND component='rise-image' limit 7
+),
+slides AS
+(
+  SELECT date, Reliability FROM `client-side-events.Display_Events.ComponentReliability` WHERE rollout_stage='stable' AND component='rise-slides' limit 7
+),
+video AS
+(
+  SELECT date, Reliability FROM `client-side-events.Display_Events.ComponentReliability` WHERE rollout_stage='stable' AND component='rise-video' limit 7
+),
+counter AS
+(
+  SELECT date, Reliability FROM `client-side-events.Display_Events.ComponentReliability` WHERE rollout_stage='stable' AND component='rise-data-counter' limit 7
+),
+risePlayerConfiguration AS
+(
+  SELECT date, Reliability FROM `client-side-events.Display_Events.ComponentReliability` WHERE rollout_stage='stable' AND component='RisePlayerConfiguration' limit 7
+),
+risePUD AS
+(
+  SELECT date, Reliability FROM `client-side-events.Display_Events.ComponentReliability` WHERE rollout_stage='stable' AND component='rise-play-until-done' limit 7
+),
+text AS
+(
+  SELECT date, Reliability FROM `client-side-events.Display_Events.ComponentReliability` WHERE rollout_stage='stable' AND component='rise-text' limit 7
+)
+
+
+SELECT date, financial_r, rss_r, weather_r, image_r, slides_r, video_r, counter_r, configuration_r, pud_r, text_r
+FROM (
+  SELECT financial.date as date,
+       financial.Reliability as financial_r,
+       rss.Reliability as rss_r,
+       weather.Reliability as weather_r,
+       image.Reliability as image_r,
+       slides.Reliability as slides_r,
+       video.Reliability as video_r,
+       counter.Reliability as counter_r,
+       risePlayerConfiguration.Reliability as configuration_r,
+       risePUD.Reliability as pud_r,
+       text.Reliability as text_r
+  FROM financial
+  LEFT JOIN rss ON DATE(TIMESTAMP(rss.date)) = financial.date
+  LEFT JOIN weather ON DATE(TIMESTAMP(weather.date)) = financial.date
+  LEFT JOIN image ON DATE(TIMESTAMP(image.date)) = financial.date
+  LEFT JOIN slides ON DATE(TIMESTAMP(slides.date)) = financial.date
+  LEFT JOIN video ON DATE(TIMESTAMP(video.date)) = financial.date
+  LEFT JOIN counter ON DATE(TIMESTAMP(counter.date)) = financial.date
+  LEFT JOIN risePlayerConfiguration ON DATE(TIMESTAMP(risePlayerConfiguration.date)) = financial.date
+  LEFT JOIN risePUD ON DATE(TIMESTAMP(risePUD.date)) = financial.date
+  LEFT JOIN text ON DATE(TIMESTAMP(text.date)) = financial.date
+)
+ORDER by date DESC


### PR DESCRIPTION
Adding this query to simplify the _components-widgets-config.js_ automated reliability script so it can run one query to extract and inject the reliability scores. Corresponding changes are in this [commit ](https://github.com/Rise-Vision/bq-sheet-insert/commit/ef4dd7b811a3244963ed28af14b3acb97f2a159e)