### PR TITLE
Shared Schedules daily Storage Usage view

### DIFF
--- a/projects/client-side-events/datasets/Apps_Events/views/SharedSchedulesStorageUsage.bq
+++ b/projects/client-side-events/datasets/Apps_Events/views/SharedSchedulesStorageUsage.bq
@@ -1,0 +1,15 @@
+#legacySQL
+SELECT 
+  DATE(TIMESTAMP(time_micros)) as date, 
+  sum(sc_bytes) as bandwidth, 
+  count(*) as requests
+
+FROM TABLE_DATE_RANGE([avid-life-623:RiseStorageLogs_v2.UsageLogs], 
+  TIMESTAMP(DATE_ADD(CURRENT_TIMESTAMP(), -7, 'DAY')),
+  TIMESTAMP(NOW())
+)
+  
+where time_micros > DATE_ADD(CURRENT_TIMESTAMP(), -7, 'DAY')
+and cs_referer contains 'type=sharedschedule'
+group by date
+order by date


### PR DESCRIPTION
### Description

A View to report daily Storage usage (bandwidth and #of request) from Shared Schedules.

### How this has been tested

As we don't have 'type=sharedschedule' requests yet, I tested with a different url parameter to validate the output.