### PR TITLE
Update SharedSchedulesStorageUsage to standard SQL

### DIFF
--- a/projects/client-side-events/datasets/Apps_Events/views/SharedSchedulesStorageUsage.bq
+++ b/projects/client-side-events/datasets/Apps_Events/views/SharedSchedulesStorageUsage.bq
@@ -1,15 +1,15 @@
-#legacySQL
-SELECT 
-  DATE(TIMESTAMP(time_micros)) as date, 
-  sum(sc_bytes) as bandwidth, 
-  count(*) as requests
-
-FROM TABLE_DATE_RANGE([avid-life-623:RiseStorageLogs_v2.UsageLogs], 
-  TIMESTAMP(DATE_ADD(CURRENT_TIMESTAMP(), -7, 'DAY')),
-  TIMESTAMP(NOW())
-)
-  
-where time_micros > DATE_ADD(CURRENT_TIMESTAMP(), -7, 'DAY')
-and cs_referer contains 'type=sharedschedule'
-group by date
-order by date
+#standardSQL
+SELECT
+  DATE(TIMESTAMP_MICROS(time_micros)) AS date,
+  SUM(sc_bytes) AS bandwidth,
+  COUNT(*) AS requests
+FROM
+  `avid-life-623.RiseStorageLogs_v2.UsageLogs*`
+WHERE
+  _table_suffix BETWEEN FORMAT_DATE("%Y%m%d", DATE_SUB(CURRENT_DATE(), INTERVAL 7 day))
+  AND FORMAT_DATE("%Y%m%d", CURRENT_DATE())
+  AND cs_referer LIKE '%type=sharedschedule%'
+GROUP BY
+  date
+ORDER BY
+  date


### PR DESCRIPTION
### Description:
Update SharedSchedulesStorageUsage to standard SQL so that it can be used with Google Data Studio (it does not support legacy SQL).

### How this has been tested
Added the results to a sample Data Studio report.