### PR TITLE
Added legacy costs calculation

### DIFF
--- a/projects/endpoint-event-logs/datasets/logs/dailyCostSummary.sql
+++ b/projects/endpoint-event-logs/datasets/logs/dailyCostSummary.sql
@@ -190,7 +190,7 @@ where DATE(H.timestamp) = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY) and eventApp 
 group by 1, 2, 3, 4
 ),
 
-endpointDownloads_legacy1 as
+endpointDownloads_legacy_display as
 (
 select 
 REGEXP_EXTRACT(URLDECODE(REGEXP_EXTRACT(cs_uri, r'parent=([^?&#]*)')), r'id=([^?&#]*)') as endpointId,
@@ -199,11 +199,11 @@ REGEXP_EXTRACT(URLDECODE(REGEXP_EXTRACT(cs_uri, r'parent=([^?&#]*)')), r'id=([^?
 sum(sc_bytes) as downloadedBytes
 from `avid-life-623.RiseStorageLogs_v2.UsageLogs*`
 where _TABLE_SUFFIX = FORMAT_DATE("%Y%m%d",DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)) and 
-(strpos(URLDECODE(cs_uri), '://widgets.risevision.com/viewer') > 0 or strpos(URLDECODE(cs_uri), '://viewer.risevision.com') > 0)
+(strpos(URLDECODE(cs_uri), '://widgets.risevision.com/viewer') > 0 or strpos(URLDECODE(cs_uri), '://viewer.risevision.com') > 0) and strpos(URLDECODE(cs_uri), 'ype=sharedschedule') <= 0
 group by 1, 2, 3
 ),
 
-endpointDownloads_legacy2 as
+endpointDownloads_legacy_display_referer as
 (
 select 
 REGEXP_EXTRACT(URLDECODE(REGEXP_EXTRACT(cs_referer, r'parent=([^?&#]*)')), r'id=([^?&#]*)') as endpointId,
@@ -212,11 +212,11 @@ REGEXP_EXTRACT(URLDECODE(REGEXP_EXTRACT(cs_referer, r'parent=([^?&#]*)')), r'id=
 sum(sc_bytes) as downloadedBytes
 from `avid-life-623.RiseStorageLogs_v2.UsageLogs*`
 where _TABLE_SUFFIX = FORMAT_DATE("%Y%m%d",DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)) and 
-(strpos(URLDECODE(cs_referer), '://widgets.risevision.com/viewer') > 0 or strpos(URLDECODE(cs_referer), '://viewer.risevision.com') > 0)
+(strpos(URLDECODE(cs_referer), '://widgets.risevision.com/viewer') > 0 or strpos(URLDECODE(cs_referer), '://viewer.risevision.com') > 0) and strpos(URLDECODE(cs_referer), 'ype=sharedschedule') <= 0
 group by 1, 2, 3
 ),
 
-endpointDownloads_legacy3 as
+endpointDownloads_legacy_embed as
 (
 select 
 REGEXP_EXTRACT(cs_uri, r'viewerId=([^?&#]*)') as endpointId,
@@ -224,11 +224,11 @@ REGEXP_EXTRACT(cs_uri, r'viewerId=([^?&#]*)') as endpointId,
 REGEXP_EXTRACT(URLDECODE(REGEXP_EXTRACT(cs_uri, r'parent=([^?&#]*)')), r'id=([^?&#]*)') as scheduleId,
 sum(sc_bytes) as downloadedBytes
 from `avid-life-623.RiseStorageLogs_v2.UsageLogs*`
-where _TABLE_SUFFIX = FORMAT_DATE("%Y%m%d",DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)) and strpos(URLDECODE(cs_uri), 'type=sharedschedule') > 0 and strpos(URLDECODE(cs_uri), '://widgets.risevision.com/viewer') > 0
+where _TABLE_SUFFIX = FORMAT_DATE("%Y%m%d",DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)) and strpos(URLDECODE(cs_uri), 'ype=sharedschedule') > 0 and strpos(URLDECODE(cs_uri), '://widgets.risevision.com/viewer') > 0
 group by 1, 2, 3
 ),
 
-endpointDownloads_legacy4 as
+endpointDownloads_legacy_url as
 (
 select 
 REGEXP_EXTRACT(cs_uri, r'viewerId=([^?&#]*)') as endpointId,
@@ -236,11 +236,11 @@ REGEXP_EXTRACT(cs_uri, r'viewerId=([^?&#]*)') as endpointId,
 '' as scheduleId,
 sum(sc_bytes) as downloadedBytes
 from `avid-life-623.RiseStorageLogs_v2.UsageLogs*`
-where _TABLE_SUFFIX = FORMAT_DATE("%Y%m%d",DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)) and strpos(URLDECODE(cs_uri), 'viewerType=sharedschedule') > 0
+where _TABLE_SUFFIX = FORMAT_DATE("%Y%m%d",DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)) and strpos(URLDECODE(cs_uri), 'ype=sharedschedule') > 0 and strpos(URLDECODE(cs_uri), '://widgets.risevision.com/viewer') <= 0
 group by 1, 2, 3
 ),
 
-endpointDownloads_legacy5 as
+endpointDownloads_legacy_embed_referer as
 (
 select 
 REGEXP_EXTRACT(cs_referer, r'viewerId=([^?&#]*)') as endpointId,
@@ -248,11 +248,11 @@ REGEXP_EXTRACT(cs_referer, r'viewerId=([^?&#]*)') as endpointId,
 REGEXP_EXTRACT(URLDECODE(REGEXP_EXTRACT(cs_referer, r'parent=([^?&#]*)')), r'id=([^?&#]*)') as scheduleId,
 sum(sc_bytes) as downloadedBytes
 from `avid-life-623.RiseStorageLogs_v2.UsageLogs*`
-where _TABLE_SUFFIX = FORMAT_DATE("%Y%m%d",DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)) and strpos(URLDECODE(cs_referer), 'type=sharedschedule') > 0 and strpos(URLDECODE(cs_referer), '://widgets.risevision.com/viewer') > 0
+where _TABLE_SUFFIX = FORMAT_DATE("%Y%m%d",DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)) and strpos(URLDECODE(cs_referer), 'ype=sharedschedule') > 0 and strpos(URLDECODE(cs_referer), '://widgets.risevision.com/viewer') > 0
 group by 1, 2, 3
 ),
 
-endpointDownloads_legacy6 as
+endpointDownloads_legacy_url_referer as
 (
 select 
 REGEXP_EXTRACT(cs_referer, r'viewerId=([^?&#]*)') as endpointId,
@@ -265,7 +265,7 @@ group by 1, 2, 3
 ),
 
 
-endpointDownloads_legacy7 as
+endpointDownloads_legacy_display_signedUrls as
 (
 select 
 REGEXP_EXTRACT(cs_uri, r'displayId=([^?&#]*)') as endpointId,
@@ -285,49 +285,49 @@ select
   endpointType,
   scheduleId,
   downloadedBytes
-from endpointDownloads_legacy1
+from endpointDownloads_legacy_display
 union distinct
 select 
   endpointId,
   endpointType,
   scheduleId,
   downloadedBytes
-from endpointDownloads_legacy2
+from endpointDownloads_legacy_display_referer
 union distinct
 select 
   endpointId,
   endpointType,
   scheduleId,
   downloadedBytes
-from endpointDownloads_legacy3
+from endpointDownloads_legacy_embed
 union distinct
 select 
   endpointId,
   endpointType,
   scheduleId,
   downloadedBytes
-from endpointDownloads_legacy4
+from endpointDownloads_legacy_embed_referer
 union distinct
 select 
   endpointId,
   endpointType,
   scheduleId,
   downloadedBytes
-from endpointDownloads_legacy5
+from endpointDownloads_legacy_url
 union distinct
 select 
   endpointId,
   endpointType,
   scheduleId,
   downloadedBytes
-from endpointDownloads_legacy6
+from endpointDownloads_legacy_url_referer
 union distinct
 select 
   endpointId,
   endpointType,
   scheduleId,
   downloadedBytes
-from endpointDownloads_legacy7
+from endpointDownloads_legacy_display_signedUrls
 ),
 
 costs as

--- a/projects/endpoint-event-logs/datasets/logs/dailyCostSummary.sql
+++ b/projects/endpoint-event-logs/datasets/logs/dailyCostSummary.sql
@@ -1,3 +1,13 @@
+CREATE TEMP FUNCTION URLDECODE(url STRING) AS ((
+  SELECT STRING_AGG(
+    IF(REGEXP_CONTAINS(y, r'^%[0-9a-fA-F]{2}'), 
+      SAFE_CONVERT_BYTES_TO_STRING(FROM_HEX(REPLACE(y, '%', ''))), y), '' 
+    ORDER BY i
+    )
+  FROM UNNEST(REGEXP_EXTRACT_ALL(url, r"%[0-9a-fA-F]{2}(?:%[0-9a-fA-F]{2})*|[^%]+")) y
+  WITH OFFSET AS i 
+));
+
 with
 
 productionCompanies as
@@ -180,6 +190,146 @@ where DATE(H.timestamp) = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY) and eventApp 
 group by 1, 2, 3, 4
 ),
 
+endpointDownloads_legacy1 as
+(
+select 
+REGEXP_EXTRACT(URLDECODE(REGEXP_EXTRACT(cs_uri, r'parent=([^?&#]*)')), r'id=([^?&#]*)') as endpointId,
+'Display' as endpointType,
+'' as scheduleId,
+sum(sc_bytes) as downloadedBytes
+from `avid-life-623.RiseStorageLogs_v2.UsageLogs*`
+where _TABLE_SUFFIX = FORMAT_DATE("%Y%m%d",DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)) and 
+(strpos(URLDECODE(cs_uri), '://widgets.risevision.com/viewer') > 0 or strpos(URLDECODE(cs_uri), '://viewer.risevision.com') > 0)
+group by 1, 2, 3
+),
+
+endpointDownloads_legacy2 as
+(
+select 
+REGEXP_EXTRACT(URLDECODE(REGEXP_EXTRACT(cs_referer, r'parent=([^?&#]*)')), r'id=([^?&#]*)') as endpointId,
+'Display' as endpointType,
+'' as scheduleId,
+sum(sc_bytes) as downloadedBytes
+from `avid-life-623.RiseStorageLogs_v2.UsageLogs*`
+where _TABLE_SUFFIX = FORMAT_DATE("%Y%m%d",DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)) and 
+(strpos(URLDECODE(cs_referer), '://widgets.risevision.com/viewer') > 0 or strpos(URLDECODE(cs_referer), '://viewer.risevision.com') > 0)
+group by 1, 2, 3
+),
+
+endpointDownloads_legacy3 as
+(
+select 
+REGEXP_EXTRACT(cs_uri, r'viewerId=([^?&#]*)') as endpointId,
+'Embed' as endpointType,
+REGEXP_EXTRACT(URLDECODE(REGEXP_EXTRACT(cs_uri, r'parent=([^?&#]*)')), r'id=([^?&#]*)') as scheduleId,
+sum(sc_bytes) as downloadedBytes
+from `avid-life-623.RiseStorageLogs_v2.UsageLogs*`
+where _TABLE_SUFFIX = FORMAT_DATE("%Y%m%d",DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)) and strpos(URLDECODE(cs_uri), 'type=sharedschedule') > 0 and strpos(URLDECODE(cs_uri), '://widgets.risevision.com/viewer') > 0
+group by 1, 2, 3
+),
+
+endpointDownloads_legacy4 as
+(
+select 
+REGEXP_EXTRACT(cs_uri, r'viewerId=([^?&#]*)') as endpointId,
+'URL' as endpointType,
+'' as scheduleId,
+sum(sc_bytes) as downloadedBytes
+from `avid-life-623.RiseStorageLogs_v2.UsageLogs*`
+where _TABLE_SUFFIX = FORMAT_DATE("%Y%m%d",DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)) and strpos(URLDECODE(cs_uri), 'viewerType=sharedschedule') > 0
+group by 1, 2, 3
+),
+
+endpointDownloads_legacy5 as
+(
+select 
+REGEXP_EXTRACT(cs_referer, r'viewerId=([^?&#]*)') as endpointId,
+'Embed' as endpointType,
+REGEXP_EXTRACT(URLDECODE(REGEXP_EXTRACT(cs_referer, r'parent=([^?&#]*)')), r'id=([^?&#]*)') as scheduleId,
+sum(sc_bytes) as downloadedBytes
+from `avid-life-623.RiseStorageLogs_v2.UsageLogs*`
+where _TABLE_SUFFIX = FORMAT_DATE("%Y%m%d",DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)) and strpos(URLDECODE(cs_referer), 'type=sharedschedule') > 0 and strpos(URLDECODE(cs_referer), '://widgets.risevision.com/viewer') > 0
+group by 1, 2, 3
+),
+
+endpointDownloads_legacy6 as
+(
+select 
+REGEXP_EXTRACT(cs_referer, r'viewerId=([^?&#]*)') as endpointId,
+'URL' as endpointType,
+'' as scheduleId,
+sum(sc_bytes) as downloadedBytes
+from `avid-life-623.RiseStorageLogs_v2.UsageLogs*`
+where _TABLE_SUFFIX = FORMAT_DATE("%Y%m%d",DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)) and strpos(URLDECODE(cs_referer), 'ype=sharedschedule') > 0 and strpos(URLDECODE(cs_referer), '://widgets.risevision.com/viewer') <= 0
+group by 1, 2, 3
+),
+
+
+endpointDownloads_legacy7 as
+(
+select 
+REGEXP_EXTRACT(cs_uri, r'displayId=([^?&#]*)') as endpointId,
+'Display' as endpointType,
+'' as scheduleId,
+sum(sc_bytes) as downloadedBytes
+from `avid-life-623.RiseStorageLogs_v2.UsageLogs*`
+where _TABLE_SUFFIX = FORMAT_DATE("%Y%m%d",DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)) 
+and strpos(cs_uri, 'GoogleAccessId=') > 0 and strpos(cs_uri, 'Signature=') > 0 and strpos(cs_uri, 'Expires=') > 0
+group by 1, 2, 3
+),
+
+endpointDownloads_legacy as
+(
+select 
+  endpointId,
+  endpointType,
+  scheduleId,
+  downloadedBytes
+from endpointDownloads_legacy1
+union distinct
+select 
+  endpointId,
+  endpointType,
+  scheduleId,
+  downloadedBytes
+from endpointDownloads_legacy2
+union distinct
+select 
+  endpointId,
+  endpointType,
+  scheduleId,
+  downloadedBytes
+from endpointDownloads_legacy3
+union distinct
+select 
+  endpointId,
+  endpointType,
+  scheduleId,
+  downloadedBytes
+from endpointDownloads_legacy4
+union distinct
+select 
+  endpointId,
+  endpointType,
+  scheduleId,
+  downloadedBytes
+from endpointDownloads_legacy5
+union distinct
+select 
+  endpointId,
+  endpointType,
+  scheduleId,
+  downloadedBytes
+from endpointDownloads_legacy6
+union distinct
+select 
+  endpointId,
+  endpointType,
+  scheduleId,
+  downloadedBytes
+from endpointDownloads_legacy7
+),
+
 costs as
 (
 select
@@ -190,9 +340,11 @@ select
     else S.companyId
   end as companyId,
   IFNULL((CAST(B.downloadedBytes as FLOAT64) * CAST(totalDownloadCost as FLOAT64)) / CAST(totalDownloaded as FLOAT64), 0.0) as dailyDirectCost,
+  IFNULL((CAST(L.downloadedBytes as FLOAT64) * CAST(totalDownloadCost as FLOAT64)) / CAST(totalDownloaded as FLOAT64), 0.0) as dailyDirectCost_legacy,
   IFNULL((CAST((IFNULL(logInsertCount, 0) +  IFNULL(heatbeatInsertCount, 0)) as FLOAT64) * CAST(totalStreamInsertCost as FLOAT64)) / CAST((totalLogInsertCount + totalHeartbeatInsertCount) as FLOAT64), 0.0) as dailyIndirectCost
 from endpoints E, downloadBandwidth, downloadCost, streamInsertCost, logInserts, heartbeatInserts
 left outer join endpointDownloads B on E.endpointId = B.endpointId and E.endpointType = B.endpointType and E.scheduleId = B.scheduleId
+left outer join endpointDownloads_legacy L on E.endpointId = L.endpointId
 left outer join endpointLogInserts LI on E.endpointId = LI.endpointId and E.endpointType = LI.endpointType and E.scheduleId = LI.scheduleId
 left outer join endpointHeartbeatInserts HI on E.endpointId = HI.endpointId and E.endpointType = HI.endpointType and E.scheduleId = HI.scheduleId
 left outer join productionDisplays D on E.endpointId = D.displayId
@@ -217,7 +369,7 @@ select
   N.companyId as networkCompanyId,
   N.name as networkCompanyName,
   N.companyIndustry as networkCompanyIndustry,
-  CO.dailyDirectCost,
+  CO.dailyDirectCost + CO.dailyDirectCost_legacy as dailyDirectCost,
   CO.dailyIndirectCost
 from costs CO
 left outer join endpointDetails D on CO.endpointId = D.endpointId


### PR DESCRIPTION
This is a change to the endpoint cost calculation that includes extracting cost data from legacy storage requests (from GCS Usage Logs), see this [diagram](https://docs.google.com/document/d/1i5E5VGaybBVLTSZ3wiTXG04Zhw8ENhdG2QDNLQXDTRo/edit?usp=sharing) for details.